### PR TITLE
Fix issue with opening existing projects

### DIFF
--- a/plugin/stemhub/Source/include/Views.hpp
+++ b/plugin/stemhub/Source/include/Views.hpp
@@ -39,6 +39,7 @@ public:
                      const std::vector<juce::String>& projectIds,
                      const juce::String& selectedProjectId);
     void setHasExistingProjects(bool hasProjects);
+    void setCanCreateProject(bool canCreate);
     juce::String getSelectedProjectId() const;
     void resized() override;
 
@@ -50,6 +51,7 @@ public:
 private:
     std::vector<juce::String> comboProjectIds;
     bool hasExistingProjects { false };
+    bool canCreateProject { false };
     juce::Label statusLabel;
     juce::Label projectFileLabel;
     juce::Label existingProjectsLabel;

--- a/plugin/stemhub/Source/src/DashboardView.cpp
+++ b/plugin/stemhub/Source/src/DashboardView.cpp
@@ -40,6 +40,7 @@ ProjectSelectionView::ProjectSelectionView()
         if (onCreateProject != nullptr)
             onCreateProject();
     };
+    createProjectButton.setVisible(false);
 
     addAndMakeVisible(signOutButton);
     signOutButton.onClick = [this]
@@ -70,6 +71,10 @@ void ProjectSelectionView::setProjects(const std::vector<juce::String>& projectN
             }
         }
     }
+    else if (!comboProjectIds.empty())
+    {
+        projectComboBox.setSelectedId(1, juce::dontSendNotification);
+    }
 }
 
 void ProjectSelectionView::setHasExistingProjects(bool hasProjects)
@@ -78,6 +83,13 @@ void ProjectSelectionView::setHasExistingProjects(bool hasProjects)
     existingProjectsLabel.setVisible(hasExistingProjects);
     projectComboBox.setVisible(hasExistingProjects);
     openProjectButton.setVisible(hasExistingProjects);
+    resized();
+}
+
+void ProjectSelectionView::setCanCreateProject(bool canCreate)
+{
+    canCreateProject = canCreate;
+    createProjectButton.setVisible(canCreateProject);
     resized();
 }
 
@@ -129,10 +141,16 @@ void ProjectSelectionView::resized()
         area.removeFromTop(16);
     }
 
-    auto createRow = area.removeFromTop(32);
-    createProjectButton.setBounds(x, createRow.getY(), fieldWidth, createRow.getHeight());
-
-    area.removeFromTop(20);
+    if (canCreateProject)
+    {
+        auto createRow = area.removeFromTop(32);
+        createProjectButton.setBounds(x, createRow.getY(), fieldWidth, createRow.getHeight());
+        area.removeFromTop(20);
+    }
+    else
+    {
+        area.removeFromTop(8);
+    }
 
     auto signOutRow = area.removeFromTop(32);
     signOutButton.setBounds(x, signOutRow.getY(), fieldWidth, signOutRow.getHeight());

--- a/plugin/stemhub/Source/src/PluginEditor.cpp
+++ b/plugin/stemhub/Source/src/PluginEditor.cpp
@@ -102,9 +102,11 @@ void StemhubAudioProcessorEditor::refreshSessionUi()
             projectIds.push_back(project.id);
         }
 
+        const auto hasSelectedProjectFile = audioProcessor.getPendingProjectFile().existsAsFile();
         projectSelectionView.setHasExistingProjects(!projects.empty());
+        projectSelectionView.setCanCreateProject(hasSelectedProjectFile);
         projectSelectionView.setMessage(getProjectSelectionMessage(audioProcessor));
-        projectSelectionView.setSelectedProjectFileMessage(audioProcessor.getPendingProjectFile().existsAsFile()
+        projectSelectionView.setSelectedProjectFileMessage(hasSelectedProjectFile
             ? audioProcessor.getPendingProjectFile().getFullPathName()
             : "No project file selected.");
         projectSelectionView.setProjects(projectNames,
@@ -150,17 +152,17 @@ void StemhubAudioProcessorEditor::handleChooseProjectFileClick()
 
 void StemhubAudioProcessorEditor::handleOpenProjectClick()
 {
-    const auto pendingFile = audioProcessor.getPendingProjectFile();
-    if (!pendingFile.existsAsFile())
+    const auto projectId = projectSelectionView.getSelectedProjectId();
+    if (projectId.isEmpty())
     {
         juce::AlertWindow::showMessageBoxAsync(
             juce::AlertWindow::WarningIcon,
             "Open project",
-            "Choose the local DAW project file before continuing.");
+            "Choose an existing project before continuing.");
         return;
     }
 
-    const auto projectId = projectSelectionView.getSelectedProjectId();
+    const auto pendingFile = audioProcessor.getPendingProjectFile();
     audioProcessor.requestOpenProject(projectId, pendingFile);
     refreshSessionUi();
 }

--- a/plugin/stemhub/Source/src/PluginProcessor.cpp
+++ b/plugin/stemhub/Source/src/PluginProcessor.cpp
@@ -118,12 +118,6 @@ StemhubAudioProcessor::ProjectActivationJobResult StemhubAudioProcessor::perform
     ProjectActivationJobResult result;
     result.projectFile = localProjectFile;
 
-    if (!localProjectFile.existsAsFile())
-    {
-        result.errorMessage = "Choose the local DAW project file before continuing.";
-        return result;
-    }
-
     if (projectId.isEmpty())
     {
         result.errorMessage = "Choose a project before continuing.";
@@ -159,7 +153,9 @@ StemhubAudioProcessor::ProjectActivationJobResult StemhubAudioProcessor::perform
     result.selectedProject = *projectIt;
     result.branchId = selectedBranch.id;
     result.branchName = selectedBranch.name;
-    result.activeProjectStatusMessage = "Project ready.";
+    result.activeProjectStatusMessage = localProjectFile.existsAsFile()
+        ? "Project ready."
+        : "Project ready. Choose a local project file before saving.";
     return result;
 }
 


### PR DESCRIPTION
**UI and interaction improvements:**

* Added a new `canCreateProject` flag and corresponding `setCanCreateProject` method to `ProjectSelectionView`, controlling the visibility of the "Create Project" button based on whether a local project file is selected. [[1]](diffhunk://#diff-33c91f1e7298b276568317d5f8b43dca92209603e331b2a6cf55a14647f1a97cR42) [[2]](diffhunk://#diff-33c91f1e7298b276568317d5f8b43dca92209603e331b2a6cf55a14647f1a97cR54) [[3]](diffhunk://#diff-1d28c31f61f400866a6bad23b0c9ca6cf32a37b9ea1d158add3f8abd2fbdbf53R43) [[4]](diffhunk://#diff-1d28c31f61f400866a6bad23b0c9ca6cf32a37b9ea1d158add3f8abd2fbdbf53R89-R95) [[5]](diffhunk://#diff-1d28c31f61f400866a6bad23b0c9ca6cf32a37b9ea1d158add3f8abd2fbdbf53R144-R153)
* Updated the UI logic in `refreshSessionUi` to call `setCanCreateProject` only if a pending project file exists, ensuring the "Create Project" button is shown only when appropriate.

**Project selection and activation logic:**

* Changed the logic in `handleOpenProjectClick` so that opening a project now requires selecting an existing project (not just a file), improving error messages and user guidance.
* Removed the requirement to have a local project file before activating a project in the processor logic, allowing project activation even without a file, but providing a status message prompting the user to select a file before saving. [[1]](diffhunk://#diff-cd032eb56d27eec1ed8585bd72659cda2881f197dc67b951887d4559ffe2ca1fL121-L126) [[2]](diffhunk://#diff-cd032eb56d27eec1ed8585bd72659cda2881f197dc67b951887d4559ffe2ca1fL162-R158)

**Project selection defaults:**

* Improved selection behavior in `setProjects` so that if there are available projects but none is selected, the first project is automatically selected.