### PR TITLE
Clear config/token exchange error for invalid Google credentials

### DIFF
--- a/backend/src/stemhub/auth.py
+++ b/backend/src/stemhub/auth.py
@@ -16,6 +16,7 @@ from .security import get_password_hash, verify_password, create_access_token, S
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl="auth/swagger-login", auto_error=False)
+INACTIVE_ACCOUNT_MESSAGE = "Your account is deactivated."
 
 GOOGLE_CLIENT_ID = os.getenv("GOOGLE_CLIENT_ID")
 GOOGLE_CLIENT_SECRET = os.getenv("GOOGLE_CLIENT_SECRET")
@@ -34,6 +35,8 @@ GOOGLE_REDIRECT_URI = ensure_https(os.getenv("GOOGLE_REDIRECT_URI", f"{BACKEND_U
 
 @router.get("/login/google")
 async def login_google():
+    if not GOOGLE_CLIENT_ID:
+        raise HTTPException(status_code=500, detail="Google OAuth is not configured (GOOGLE_CLIENT_ID missing).")
     state = secrets.token_urlsafe(32)
     response = RedirectResponse(
         url=f"https://accounts.google.com/o/oauth2/v2/auth?response_type=code&client_id={GOOGLE_CLIENT_ID}&redirect_uri={GOOGLE_REDIRECT_URI}&scope=openid%20profile%20email&access_type=offline&prompt=select_account&state={state}"
@@ -50,6 +53,8 @@ async def login_google():
 
 @router.get("/callback/google")
 async def callback_google(request: Request, code: str, state: str | None = None, db: AsyncSession = Depends(get_db)):
+    if not GOOGLE_CLIENT_ID or not GOOGLE_CLIENT_SECRET:
+        raise HTTPException(status_code=500, detail="Google OAuth is not configured (GOOGLE_CLIENT_ID/GOOGLE_CLIENT_SECRET missing).")
     cookie_state = request.cookies.get("oauth_state")
     if not state or not cookie_state or not secrets.compare_digest(state, cookie_state):
         raise HTTPException(status_code=400, detail="Invalid state parameter")
@@ -64,6 +69,14 @@ async def callback_google(request: Request, code: str, state: str | None = None,
             "redirect_uri": GOOGLE_REDIRECT_URI
         })
         token_data = token_res.json()
+        if token_data.get("error"):
+            error_code = token_data.get("error")
+            error_description = token_data.get("error_description") or "OAuth token exchange failed."
+            raise HTTPException(
+                status_code=400,
+                detail=f"{error_code}: {error_description}"
+            )
+
         access_token = token_data.get("access_token")
 
         if not access_token:
@@ -80,6 +93,7 @@ async def callback_google(request: Request, code: str, state: str | None = None,
 
         result = await db.execute(select(User).where(User.email == email))
         user = result.scalars().first()
+        reactivated = False
 
         if not user:
             base_username = name.replace(" ", "").lower() if name else email.split("@")[0]
@@ -95,6 +109,14 @@ async def callback_google(request: Request, code: str, state: str | None = None,
             password_hash = get_password_hash(urllib.parse.quote(email) + "oauth_dummy")
             user = User(email=email, username=username, password_hash=password_hash, avatar_url=avatar_url)
             db.add(user)
+            reactivated = True
+        else:
+            user.avatar_url = avatar_url
+            if not user.is_active:
+                user.is_active = True
+                reactivated = True
+
+        if reactivated:
             await db.commit()
             await db.refresh(user)
 
@@ -144,6 +166,12 @@ async def swagger_login(response: RedirectResponse, form_data: OAuth2PasswordReq
     # Swagger sends the user input in the "username" field, but we log in with email
     result = await db.execute(select(User).where(User.email == form_data.username))
     user = result.scalars().first()
+    if user and not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=INACTIVE_ACCOUNT_MESSAGE,
+            headers={"WWW-Authenticate": "Bearer"},
+        )
     if not user or not verify_password(form_data.password, user.password_hash):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -167,6 +195,12 @@ async def swagger_login(response: RedirectResponse, form_data: OAuth2PasswordReq
 async def login(credentials: LoginRequest, response: RedirectResponse, db: AsyncSession = Depends(get_db)):
     result = await db.execute(select(User).where(User.email == credentials.email))
     user = result.scalars().first()
+    if user and not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=INACTIVE_ACCOUNT_MESSAGE,
+            headers={"WWW-Authenticate": "Bearer"},
+        )
     if not user or not verify_password(credentials.password, user.password_hash):
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -224,7 +258,7 @@ async def get_current_user(request: Request, db: AsyncSession = Depends(get_db))
     except jwt.PyJWTError:
         raise credentials_exception
         
-    result = await db.execute(select(User).where(User.email == email))
+    result = await db.execute(select(User).where(User.email == email, User.is_active == True))
     user = result.scalars().first()
     if user is None:
         raise credentials_exception


### PR DESCRIPTION
**Authentication and account status enforcement:**

* Added checks in both the Swagger and API login endpoints to prevent deactivated users from logging in, returning a clear error message if the account is inactive. [[1]](diffhunk://#diff-a8fd7d716831419276cb6ba2e1d8f02c3596cb6050e3c51afa7ba3f39cd62836R169-R174) [[2]](diffhunk://#diff-a8fd7d716831419276cb6ba2e1d8f02c3596cb6050e3c51afa7ba3f39cd62836R198-R203)
* Updated the `get_current_user` function to only retrieve users whose `is_active` flag is `True`, ensuring deactivated accounts cannot access protected endpoints.

**Google OAuth improvements:**

* Added explicit checks for missing `GOOGLE_CLIENT_ID` and `GOOGLE_CLIENT_SECRET` environment variables, returning a 500 error if Google OAuth is not properly configured. [[1]](diffhunk://#diff-a8fd7d716831419276cb6ba2e1d8f02c3596cb6050e3c51afa7ba3f39cd62836R38-R39) [[2]](diffhunk://#diff-a8fd7d716831419276cb6ba2e1d8f02c3596cb6050e3c51afa7ba3f39cd62836R56-R57)
* Improved error handling during the OAuth token exchange by raising an HTTP 400 error with details if Google returns an error response.
* Ensured that if a user logs in via Google and their account is deactivated, it is automatically reactivated and their avatar is updated. [[1]](diffhunk://#diff-a8fd7d716831419276cb6ba2e1d8f02c3596cb6050e3c51afa7ba3f39cd62836R96) [[2]](diffhunk://#diff-a8fd7d716831419276cb6ba2e1d8f02c3596cb6050e3c51afa7ba3f39cd62836R112-R119)

**Other:**

* Introduced a constant `INACTIVE_ACCOUNT_MESSAGE` for consistent messaging when a deactivated account attempts to log in.… when credentials are invalid