### PR TITLE
Stabilize plugin selection and enhance session recovery

### DIFF
--- a/.github/workflows/plugin-build.yml
+++ b/.github/workflows/plugin-build.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "plugin/stemhub/Source/**"
+      - "plugin/stemhub/tests/**"
       - "plugin/stemhub/CMakeLists.txt"
       - ".github/workflows/plugin-build.yml"
   push:
@@ -11,6 +12,7 @@ on:
       - main
     paths:
       - "plugin/stemhub/Source/**"
+      - "plugin/stemhub/tests/**"
       - "plugin/stemhub/CMakeLists.txt"
       - ".github/workflows/plugin-build.yml"
   workflow_dispatch:
@@ -64,8 +66,15 @@ jobs:
       - name: Configure CMake
         run: cmake -S plugin/stemhub -B build/plugin-linux -G Ninja -DCMAKE_BUILD_TYPE=Release -DCOPY_PLUGIN=OFF -DJUCE_DIR="$GITHUB_WORKSPACE/build/juce"
 
-      - name: Build plugin
-        run: cmake --build build/plugin-linux --parallel
+      - name: Build plugin and headless plugin tests
+        run: cmake --build build/plugin-linux --target stemhub_VST3 stemhub_plugin_tests --parallel
+
+      - name: Run headless plugin tests
+        run: |
+          test_bin="$(find build/plugin-linux/stemhub_plugin_tests_artefacts -type f -name 'stemhub_plugin_tests' -print -quit)"
+          test -n "$test_bin"
+          echo "Running plugin tests: $test_bin"
+          "$test_bin"
 
       - name: Verify VST3 artifact exists
         run: |

--- a/plugin/stemhub/CMakeLists.txt
+++ b/plugin/stemhub/CMakeLists.txt
@@ -74,3 +74,48 @@ target_link_libraries(stemhub
         juce::juce_recommended_config_flags
         juce::juce_recommended_lto_flags
         juce::juce_recommended_warning_flags)
+
+juce_add_console_app(stemhub_plugin_tests
+    PRODUCT_NAME "stemhub-plugin-tests")
+
+juce_generate_juce_header(stemhub_plugin_tests)
+
+target_sources(stemhub_plugin_tests
+    PRIVATE
+        Source/src/application/ProcAudio.cpp
+        Source/src/application/ProcAuth.cpp
+        Source/src/application/ProcProject.cpp
+        Source/src/application/ProcProjJobs.cpp
+        Source/src/application/ProcVerJobs.cpp
+        Source/src/application/PluginProcessor.cpp
+        Source/src/application/ProjectFileService.cpp
+        Source/src/application/SessionCache.cpp
+        Source/src/application/SnapshotBundler.cpp
+        Source/src/network/ApiClient.cpp
+        Source/src/network/VersionControlService.cpp
+        tests/ProcessorStabilityTests.cpp)
+
+target_include_directories(stemhub_plugin_tests
+    PRIVATE
+        Source/include)
+
+target_compile_definitions(stemhub_plugin_tests
+    PRIVATE
+        STEMHUB_PLUGIN_HEADLESS_TESTS=1
+        JUCE_USE_CURL=1
+        JUCE_WEB_BROWSER=0
+        JUCE_MODAL_LOOPS_PERMITTED=1
+        JUCE_STRICT_REFCOUNTEDPOINTER=1
+        JUCE_VST3_CAN_REPLACE_VST2=0
+        JucePlugin_Name="Stemhub Session"
+        JucePlugin_WantsMidiInput=0
+        JucePlugin_ProducesMidiOutput=0
+        JucePlugin_IsMidiEffect=0
+        JucePlugin_IsSynth=0)
+
+target_link_libraries(stemhub_plugin_tests
+    PRIVATE
+        juce::juce_audio_utils
+        juce::juce_recommended_config_flags
+        juce::juce_recommended_lto_flags
+        juce::juce_recommended_warning_flags)

--- a/plugin/stemhub/CMakeLists.txt
+++ b/plugin/stemhub/CMakeLists.txt
@@ -20,6 +20,7 @@ if(JUCE_DIR STREQUAL "")
 endif()
 
 add_subdirectory(${JUCE_DIR} JUCE)
+find_package(CURL REQUIRED)
 
 juce_add_plugin(stemhub
     COMPANY_NAME "Stemhub"
@@ -115,6 +116,7 @@ target_compile_definitions(stemhub_plugin_tests
 
 target_link_libraries(stemhub_plugin_tests
     PRIVATE
+        CURL::libcurl
         juce::juce_audio_utils
         juce::juce_recommended_config_flags
         juce::juce_recommended_lto_flags

--- a/plugin/stemhub/Source/include/application/BackgroundJobCoordinator.hpp
+++ b/plugin/stemhub/Source/include/application/BackgroundJobCoordinator.hpp
@@ -56,7 +56,12 @@ public:
             if (currentGeneration != requestGeneration.load())
                 return;
 
-            JobResult result { currentGeneration, requestId, taskFn() };
+            auto payload = taskFn();
+
+            if (currentGeneration != requestGeneration.load())
+                return;
+
+            JobResult result { currentGeneration, requestId, std::move(payload) };
 
             {
                 const std::lock_guard<std::mutex> lock(resultMutex);

--- a/plugin/stemhub/Source/include/application/PluginProcessor.hpp
+++ b/plugin/stemhub/Source/include/application/PluginProcessor.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <JuceHeader.h>
 #include <optional>
+#include <atomic>
 #include <vector>
 #include <variant>
 #include "application/BackgroundJobCoordinator.hpp"
@@ -100,6 +101,7 @@ public:
     void setSelectedVersionId(juce::String versionId);
     VersionControlService& getVersionControlService() noexcept { return versionControlService; }
     IProjectApi& getApiClient() noexcept { return *apiClient; }
+    void flushPendingBackgroundResultsForTesting();
 
 private:
     void handleAsyncUpdate() override;
@@ -116,6 +118,7 @@ private:
 
     struct ProjectActivationJobResult
     {
+        uint64_t selectionRequestId {};
         std::optional<Project> selectedProject;
         std::vector<Project> projects;
         std::vector<Branch> branches;
@@ -129,10 +132,12 @@ private:
         juce::String activeProjectStatusMessage;
         bool refreshProjects { false };
         bool shouldAutoOpenLocalFile { true };
+        bool fromCachedProjectRestore { false };
     };
 
     struct BranchHistoryJobResult
     {
+        uint64_t selectionRequestId {};
         std::vector<VersionSummary> versions;
         juce::String branchId;
         juce::String branchName;
@@ -193,6 +198,8 @@ private:
     void requestRestoreCachedProjectContext();
     void setWorkingCopyContext(const juce::File& workingFile, const juce::String& versionId);
     void clearWorkingCopyContext();
+    uint64_t beginSelectionRequest() noexcept;
+    [[nodiscard]] bool isCurrentSelectionRequest(uint64_t requestId) const noexcept;
     [[nodiscard]] bool hasCleanWorkingCopy(const juce::File& workingFile) const;
     [[nodiscard]] juce::String getCurrentOpenedVersionIdFromPath() const;
     void setCurrentOpenedVersionId(juce::String versionId);
@@ -223,4 +230,5 @@ private:
     int64 workingCopyFileSize { 0 };
     int64 workingCopyFileModTime { 0 };
     bool didAttemptCachedSessionRestore { false };
+    std::atomic<uint64_t> activeSelectionRequestId { 0 };
 };

--- a/plugin/stemhub/Source/include/application/SessionCache.hpp
+++ b/plugin/stemhub/Source/include/application/SessionCache.hpp
@@ -10,5 +10,10 @@ juce::String loadLastOpenedProjectFilePath();
 void saveAccessToken(const juce::String& token);
 void saveProjectId(const juce::String& projectId);
 void saveLastOpenedProjectFilePath(const juce::String& projectFilePath);
+void clearProjectId();
+void clearLastOpenedProjectFilePath();
+void clearProjectContext();
+void setCacheFileOverrideForTesting(const juce::File& file);
+void clearCacheFileOverrideForTesting();
 void clear();
 }

--- a/plugin/stemhub/Source/src/application/PluginProcessor.cpp
+++ b/plugin/stemhub/Source/src/application/PluginProcessor.cpp
@@ -69,6 +69,7 @@ StemhubAudioProcessor::StemhubAudioProcessor()
 StemhubAudioProcessor::~StemhubAudioProcessor()
 {
     juce::Logger::writeToLog("StemhubAudioProcessor destructor");
+    backgroundJobs.invalidateSession();
     cancelPendingUpdate();
     uninstallStemhubFileLogger();
 }

--- a/plugin/stemhub/Source/src/application/ProcAudio.cpp
+++ b/plugin/stemhub/Source/src/application/ProcAudio.cpp
@@ -120,12 +120,20 @@ void StemhubAudioProcessor::processBlock(juce::AudioBuffer<double>& buffer, juce
 
 bool StemhubAudioProcessor::hasEditor() const
 {
+#if STEMHUB_PLUGIN_HEADLESS_TESTS
+    return false;
+#else
     return true;
+#endif
 }
 
 juce::AudioProcessorEditor* StemhubAudioProcessor::createEditor()
 {
+#if STEMHUB_PLUGIN_HEADLESS_TESTS
+    return nullptr;
+#else
     return new StemhubAudioProcessorEditor(*this);
+#endif
 }
 
 void StemhubAudioProcessor::getStateInformation(juce::MemoryBlock& destData)
@@ -142,4 +150,3 @@ juce::AudioProcessor* JUCE_CALLTYPE createPluginFilter()
 {
     return new StemhubAudioProcessor();
 }
-

--- a/plugin/stemhub/Source/src/application/ProcAuth.cpp
+++ b/plugin/stemhub/Source/src/application/ProcAuth.cpp
@@ -15,8 +15,17 @@ void StemhubAudioProcessor::applyAuthRequestResult(AuthRequestResult result)
             currentUser.reset();
             access_tkn.clear();
             versionControlService.clearAccessToken();
-            authErrorMessage.clear();
-            sessionState = {};
+            projectSelectionStatusMessage.clear();
+            activeProjectStatusMessage.clear();
+            projects.clear();
+            branches.clear();
+            versionHistory.clear();
+            selectedVersionId.clear();
+            clearSelectedProject();
+            pendingProjectFile = juce::File();
+            selectedProjectFile = juce::File();
+            authErrorMessage = "Saved session expired. Please sign in again.";
+            setAuthState(AuthState::authError);
             sendChangeMessage();
             return;
         }
@@ -150,11 +159,22 @@ void StemhubAudioProcessor::requestRestoreCachedProjectContext()
         return project.id == cachedProjectId;
     });
     if (projectIt == projects.end())
+    {
+        stemhub::sessioncache::clearProjectContext();
+        setOperationState(OperationState::idle);
+        projectSelectionStatusMessage = "Last opened project is no longer available. Choose another project.";
+        sendChangeMessage();
         return;
+    }
 
     const auto cachedProjectFilePath = stemhub::sessioncache::loadLastOpenedProjectFilePath().trim();
     const auto cachedProjectFile = juce::File(cachedProjectFilePath);
-    const auto localProjectFile = cachedProjectFile.existsAsFile() ? cachedProjectFile : juce::File();
+    const auto hasCachedProjectFilePath = cachedProjectFilePath.isNotEmpty();
+    const auto hasUsableCachedProjectFile = cachedProjectFile.existsAsFile();
+    if (hasCachedProjectFilePath && !hasUsableCachedProjectFile)
+        stemhub::sessioncache::clearLastOpenedProjectFilePath();
+
+    const auto localProjectFile = hasUsableCachedProjectFile ? cachedProjectFile : juce::File();
     juce::Logger::writeToLog("[Restore] CachedProjectContext -> projectId="
                              + cachedProjectId
                              + ", cachedProjectFilePath="
@@ -168,10 +188,13 @@ void StemhubAudioProcessor::requestRestoreCachedProjectContext()
 
     const auto projectsSnapshot = projects;
     const auto token = access_tkn;
-    enqueueBackgroundTask([this, cachedProjectId, projectsSnapshot, token, localProjectFile]() -> BackgroundJobPayload
+    const auto selectionRequestId = beginSelectionRequest();
+    enqueueBackgroundTask([this, cachedProjectId, projectsSnapshot, token, localProjectFile, selectionRequestId]() -> BackgroundJobPayload
     {
         auto result = performOpenProjectRequest(cachedProjectId, localProjectFile, projectsSnapshot, token, false);
+        result.selectionRequestId = selectionRequestId;
         result.shouldAutoOpenLocalFile = false;
+        result.fromCachedProjectRestore = true;
         return result;
     });
 }

--- a/plugin/stemhub/Source/src/application/ProcProject.cpp
+++ b/plugin/stemhub/Source/src/application/ProcProject.cpp
@@ -34,8 +34,14 @@ juce::String resolveOpenedVersionFromPath(const juce::File& projectFile,
 
 void StemhubAudioProcessor::applyProjectActivationResult(ProjectActivationJobResult result)
 {
+    if (!isCurrentSelectionRequest(result.selectionRequestId))
+        return;
+
     if (hasError(result))
     {
+        if (result.fromCachedProjectRestore)
+            stemhub::sessioncache::clearProjectContext();
+
         setOperationState(OperationState::error);
         projectSelectionStatusMessage = result.errorMessage;
         return;
@@ -80,6 +86,9 @@ void StemhubAudioProcessor::applyProjectActivationResult(ProjectActivationJobRes
 
 void StemhubAudioProcessor::applyBranchHistoryResult(BranchHistoryJobResult result)
 {
+    if (!isCurrentSelectionRequest(result.selectionRequestId))
+        return;
+
     if (hasError(result))
     {
         setOperationState(OperationState::error);
@@ -309,6 +318,16 @@ void StemhubAudioProcessor::clearWorkingCopyContext()
     currentOpenedVersionId.clear();
 }
 
+uint64_t StemhubAudioProcessor::beginSelectionRequest() noexcept
+{
+    return ++activeSelectionRequestId;
+}
+
+bool StemhubAudioProcessor::isCurrentSelectionRequest(uint64_t requestId) const noexcept
+{
+    return requestId != 0 && requestId == activeSelectionRequestId.load();
+}
+
 bool StemhubAudioProcessor::hasCleanWorkingCopy(const juce::File& workingFile) const
 {
     if (!workingCopyVersionId.isNotEmpty())
@@ -396,18 +415,22 @@ void StemhubAudioProcessor::requestOpenProject(juce::String projectId, juce::Fil
 
     const auto projectsSnapshot = projects;
     const auto token = access_tkn;
+    const auto selectionRequestId = beginSelectionRequest();
     enqueueBackgroundTask([this,
                            requestedProjectId = std::move(projectId),
                            requestedProjectFile = std::move(localProjectFile),
                            requestedPreferRemoteLatest = preferRemoteLatest,
                            projectsSnapshot,
+                           selectionRequestId,
                            token]() -> BackgroundJobPayload
     {
-        return performOpenProjectRequest(requestedProjectId,
-                                        requestedProjectFile,
-                                        projectsSnapshot,
-                                        token,
-                                        requestedPreferRemoteLatest);
+        auto result = performOpenProjectRequest(requestedProjectId,
+                                                requestedProjectFile,
+                                                projectsSnapshot,
+                                                token,
+                                                requestedPreferRemoteLatest);
+        result.selectionRequestId = selectionRequestId;
+        return result;
     });
 }
 
@@ -417,11 +440,15 @@ void StemhubAudioProcessor::requestCreateProject(juce::File localProjectFile)
     sendChangeMessage();
 
     const auto token = access_tkn;
+    const auto selectionRequestId = beginSelectionRequest();
     enqueueBackgroundTask([this,
                            requestedProjectFile = std::move(localProjectFile),
+                           selectionRequestId,
                            token]() -> BackgroundJobPayload
     {
-        return performCreateProjectRequest(requestedProjectFile, token);
+        auto result = performCreateProjectRequest(requestedProjectFile, token);
+        result.selectionRequestId = selectionRequestId;
+        return result;
     });
 }
 
@@ -451,12 +478,16 @@ void StemhubAudioProcessor::requestSelectBranch(juce::String branchId)
 
     const auto token = access_tkn;
     const auto branchName = branchIt->name;
+    const auto selectionRequestId = beginSelectionRequest();
     enqueueBackgroundTask([this,
                            requestedBranchId = std::move(branchId),
                            requestedBranchName = std::move(branchName),
+                           selectionRequestId,
                            token]() -> BackgroundJobPayload
     {
-        return performFetchBranchHistoryRequest(requestedBranchId, requestedBranchName, {}, token);
+        auto result = performFetchBranchHistoryRequest(requestedBranchId, requestedBranchName, {}, token);
+        result.selectionRequestId = selectionRequestId;
+        return result;
     });
 }
 
@@ -481,13 +512,17 @@ void StemhubAudioProcessor::requestRefreshVersionHistory()
     const auto token = access_tkn;
     const auto branchId = selectedBranchId;
     const auto preferredVersionId = selectedVersionId;
+    const auto selectionRequestId = beginSelectionRequest();
     enqueueBackgroundTask([this,
                            branchId,
                            branchName,
                            preferredVersionId,
+                           selectionRequestId,
                            token]() -> BackgroundJobPayload
     {
-        return performFetchBranchHistoryRequest(branchId, branchName, preferredVersionId, token);
+        auto result = performFetchBranchHistoryRequest(branchId, branchName, preferredVersionId, token);
+        result.selectionRequestId = selectionRequestId;
+        return result;
     });
 }
 
@@ -569,6 +604,11 @@ void StemhubAudioProcessor::setSelectedVersionId(juce::String versionId)
 {
     selectedVersionId = std::move(versionId);
     sendChangeMessage();
+}
+
+void StemhubAudioProcessor::flushPendingBackgroundResultsForTesting()
+{
+    handleAsyncUpdate();
 }
 
 void StemhubAudioProcessor::handleAsyncUpdate()

--- a/plugin/stemhub/Source/src/application/SessionCache.cpp
+++ b/plugin/stemhub/Source/src/application/SessionCache.cpp
@@ -2,8 +2,15 @@
 
 namespace
 {
+juce::File cacheFileOverride;
+bool useInMemoryCacheOverride = false;
+juce::var inMemoryCacheOverride;
+
 juce::File resolveSessionCacheFile()
 {
+    if (cacheFileOverride.getFullPathName().isNotEmpty())
+        return cacheFileOverride;
+
     return juce::File::getSpecialLocation(juce::File::userApplicationDataDirectory)
         .getChildFile("Stemhub")
         .getChildFile("session.json");
@@ -11,6 +18,9 @@ juce::File resolveSessionCacheFile()
 
 juce::var loadCachedSessionJson()
 {
+    if (useInMemoryCacheOverride)
+        return inMemoryCacheOverride;
+
     const auto sessionFile = resolveSessionCacheFile();
     if (!sessionFile.existsAsFile())
         return {};
@@ -21,6 +31,20 @@ juce::var loadCachedSessionJson()
 
 void updateCachedSession(const std::function<void(juce::DynamicObject&)>& updater)
 {
+    if (useInMemoryCacheOverride)
+    {
+        const auto existing = loadCachedSessionJson();
+        juce::DynamicObject::Ptr sessionObject;
+        if (auto* object = existing.getDynamicObject(); object != nullptr)
+            sessionObject = object;
+        else
+            sessionObject = new juce::DynamicObject();
+
+        updater(*sessionObject);
+        inMemoryCacheOverride = juce::var(sessionObject.get());
+        return;
+    }
+
     const auto sessionFile = resolveSessionCacheFile();
     const auto sessionDirectory = sessionFile.getParentDirectory();
     if ((!sessionDirectory.exists() && !sessionDirectory.createDirectory()) || !sessionDirectory.isDirectory())
@@ -97,8 +121,53 @@ void saveLastOpenedProjectFilePath(const juce::String& projectFilePath)
     });
 }
 
+void clearProjectId()
+{
+    updateCachedSession([](juce::DynamicObject& sessionObject)
+    {
+        sessionObject.removeProperty("last_project_id");
+    });
+}
+
+void clearLastOpenedProjectFilePath()
+{
+    updateCachedSession([](juce::DynamicObject& sessionObject)
+    {
+        sessionObject.removeProperty("last_opened_project_file");
+    });
+}
+
+void clearProjectContext()
+{
+    updateCachedSession([](juce::DynamicObject& sessionObject)
+    {
+        sessionObject.removeProperty("last_project_id");
+        sessionObject.removeProperty("last_opened_project_file");
+    });
+}
+
+void setCacheFileOverrideForTesting(const juce::File& file)
+{
+    cacheFileOverride = file;
+    useInMemoryCacheOverride = true;
+    inMemoryCacheOverride = juce::var();
+}
+
+void clearCacheFileOverrideForTesting()
+{
+    cacheFileOverride = juce::File();
+    useInMemoryCacheOverride = false;
+    inMemoryCacheOverride = juce::var();
+}
+
 void clear()
 {
+    if (useInMemoryCacheOverride)
+    {
+        inMemoryCacheOverride = juce::var();
+        return;
+    }
+
     const auto sessionFile = resolveSessionCacheFile();
     if (sessionFile.existsAsFile())
         sessionFile.deleteFile();

--- a/plugin/stemhub/tests/ProcessorStabilityTests.cpp
+++ b/plugin/stemhub/tests/ProcessorStabilityTests.cpp
@@ -1,0 +1,552 @@
+#include <map>
+#include <memory>
+#include <utility>
+
+#include <JuceHeader.h>
+
+#include "application/PluginProcessor.hpp"
+#include "application/SessionCache.hpp"
+
+namespace
+{
+ApiResult<LoginResponse> makeLoginResult(const juce::String& accessToken)
+{
+    LoginResponse response;
+    response.accessToken = accessToken;
+    response.tokenType = "bearer";
+    return { response, {} };
+}
+
+ApiResult<User> makeUserResult()
+{
+    User user;
+    user.id = "user-1";
+    user.email = "user@example.com";
+    user.username = "stemhub";
+    return { user, {} };
+}
+
+ApiResult<std::vector<Project>> makeProjectsResult(std::vector<Project> projects)
+{
+    return { std::move(projects), {} };
+}
+
+ApiResult<std::vector<Branch>> makeBranchesResult(std::vector<Branch> branches)
+{
+    return { std::move(branches), {} };
+}
+
+ApiResult<juce::var> makeVersionsResult(const std::vector<VersionSummary>& versions)
+{
+    juce::Array<juce::var> versionArray;
+    for (const auto& version : versions)
+    {
+        auto* object = new juce::DynamicObject();
+        object->setProperty("id", version.id);
+        object->setProperty("branch_id", version.branchId);
+        object->setProperty("parent_version_id", version.parentVersionId);
+        object->setProperty("created_at", version.createdAt);
+        object->setProperty("commit_message", version.commitMessage);
+        object->setProperty("source_daw", version.sourceDaw);
+        object->setProperty("source_project_filename", version.sourceProjectFilename);
+        object->setProperty("artifact_path", version.artifactPath);
+        object->setProperty("artifact_checksum", version.artifactChecksum);
+        object->setProperty("artifact_size_bytes", version.artifactSizeBytes);
+        versionArray.add(juce::var(object));
+    }
+
+    return { juce::var(versionArray), {} };
+}
+
+ApiResult<juce::var> makeApiError(const juce::String& message, int statusCode = 500)
+{
+    return { {}, ApiError { statusCode, message } };
+}
+
+ApiResult<std::vector<Branch>> makeBranchError(const juce::String& message, int statusCode = 500)
+{
+    return { {}, ApiError { statusCode, message } };
+}
+
+ApiResult<User> makeUserError(const juce::String& message, int statusCode = 401)
+{
+    return { {}, ApiError { statusCode, message } };
+}
+
+class BlockingGate
+{
+public:
+    void waitUntilEntered()
+    {
+        expectEntered.wait(2000);
+    }
+
+    void release()
+    {
+        allowContinue.signal();
+    }
+
+    void waitUntilFinished()
+    {
+        finished.wait(2000);
+    }
+
+    void block()
+    {
+        expectEntered.signal();
+        allowContinue.wait(2000);
+        finished.signal();
+    }
+
+private:
+    juce::WaitableEvent expectEntered;
+    juce::WaitableEvent allowContinue;
+    juce::WaitableEvent finished;
+};
+
+class FakeProjectApi final : public IProjectApi
+{
+public:
+    ApiResult<LoginResponse> login(const juce::String& email, const juce::String& password) const override
+    {
+        juce::ignoreUnused(email, password);
+        return makeLoginResult("token");
+    }
+
+    ApiResult<User> fetchCurrentUser(const juce::String& accessToken) const override
+    {
+        juce::ignoreUnused(accessToken);
+        if (!cachedSessionIsValid)
+            return makeUserError("expired");
+
+        return makeUserResult();
+    }
+
+    ApiResult<std::vector<Project>> fetchProjects(const juce::String& accessToken) const override
+    {
+        juce::ignoreUnused(accessToken);
+        return makeProjectsResult(projects);
+    }
+
+    ApiResult<Project> createProject(const juce::String& name, const juce::String& accessToken) const override
+    {
+        juce::ignoreUnused(name, accessToken);
+        return { {}, ApiError { 500, "not implemented in tests" } };
+    }
+
+    ApiResult<std::vector<Branch>> fetchBranches(const juce::String& projectId, const juce::String& accessToken) const override
+    {
+        juce::ignoreUnused(accessToken);
+
+        if (auto it = branchFetchGates.find(projectId); it != branchFetchGates.end() && it->second != nullptr)
+            it->second->block();
+
+        if (auto it = branchErrors.find(projectId); it != branchErrors.end())
+            return makeBranchError(it->second);
+
+        if (auto it = projectBranches.find(projectId); it != projectBranches.end())
+            return makeBranchesResult(it->second);
+
+        return makeBranchError("No workspaces found for this project.");
+    }
+
+    ApiResult<juce::var> requestJson(const juce::String& path,
+                                     const juce::String& httpMethod,
+                                     const juce::String& requestBody,
+                                     const juce::String& bearerToken) const override
+    {
+        juce::ignoreUnused(requestBody, bearerToken);
+
+        if (httpMethod == "GET" && path.startsWith("/branches/") && path.endsWith("/versions/"))
+        {
+            auto branchId = path.fromFirstOccurrenceOf("/branches/", false, false)
+                .upToLastOccurrenceOf("/versions/", false, false);
+
+            if (auto it = versionFetchGates.find(branchId); it != versionFetchGates.end() && it->second != nullptr)
+                it->second->block();
+
+            if (auto it = versionErrors.find(branchId); it != versionErrors.end())
+                return makeApiError(it->second);
+
+            if (auto it = branchVersions.find(branchId); it != branchVersions.end())
+                return makeVersionsResult(it->second);
+
+            return makeVersionsResult({});
+        }
+
+        return makeApiError("Unhandled request in test API.");
+    }
+
+    ApiResult<juce::var> uploadFile(const juce::String& path,
+                                    const juce::File& file,
+                                    const juce::String& formFieldName,
+                                    const juce::String& bearerToken) const override
+    {
+        juce::ignoreUnused(path, file, formFieldName, bearerToken);
+        return makeApiError("upload not implemented in tests");
+    }
+
+    juce::Result downloadFile(const juce::String& path,
+                              const juce::File& destinationFile,
+                              const juce::String& bearerToken) const override
+    {
+        juce::ignoreUnused(path, destinationFile, bearerToken);
+        return juce::Result::fail("download not implemented in tests");
+    }
+
+    bool cachedSessionIsValid { true };
+    std::vector<Project> projects;
+    std::map<juce::String, std::vector<Branch>> projectBranches;
+    std::map<juce::String, std::vector<VersionSummary>> branchVersions;
+    std::map<juce::String, juce::String> branchErrors;
+    std::map<juce::String, juce::String> versionErrors;
+    std::map<juce::String, std::shared_ptr<BlockingGate>> branchFetchGates;
+    std::map<juce::String, std::shared_ptr<BlockingGate>> versionFetchGates;
+};
+
+Project makeProject(const juce::String& id, const juce::String& name)
+{
+    Project project;
+    project.id = id;
+    project.ownerId = "user-1";
+    project.name = name;
+    return project;
+}
+
+Branch makeBranch(const juce::String& id, const juce::String& projectId, const juce::String& name)
+{
+    Branch branch;
+    branch.id = id;
+    branch.projectId = projectId;
+    branch.name = name;
+    return branch;
+}
+
+VersionSummary makeVersion(const juce::String& id, const juce::String& branchId, const juce::String& commit)
+{
+    VersionSummary version;
+    version.id = id;
+    version.branchId = branchId;
+    version.commitMessage = commit;
+    version.createdAt = "2026-03-18T10:00:00Z";
+    return version;
+}
+
+const char* toString(AuthState state)
+{
+    switch (state)
+    {
+        case AuthState::signedOut: return "signedOut";
+        case AuthState::signingIn: return "signingIn";
+        case AuthState::signedIn: return "signedIn";
+        case AuthState::authError: return "authError";
+    }
+
+    return "unknown";
+}
+
+const char* toString(UIState state)
+{
+    switch (state)
+    {
+        case UIState::login: return "login";
+        case UIState::projectSelection: return "projectSelection";
+        case UIState::dashboard: return "dashboard";
+    }
+
+    return "unknown";
+}
+
+const char* toString(OperationState state)
+{
+    switch (state)
+    {
+        case OperationState::idle: return "idle";
+        case OperationState::loadingProjects: return "loadingProjects";
+        case OperationState::committing: return "committing";
+        case OperationState::pulling: return "pulling";
+        case OperationState::error: return "error";
+    }
+
+    return "unknown";
+}
+
+juce::String describeProcessorState(const StemhubAudioProcessor& processor)
+{
+    return "auth=" + juce::String(toString(processor.getAuthState()))
+        + ", ui=" + juce::String(toString(processor.getUIState()))
+        + ", op=" + juce::String(toString(processor.getOperationState()))
+        + ", authError=" + processor.getAuthErrorMessage()
+        + ", projectMessage=" + processor.getProjectSelectionStatusMessage()
+        + ", activeMessage=" + processor.getActiveProjectStatusMessage()
+        + ", selectedProject=" + (processor.getSelectedProject().has_value() ? processor.getSelectedProject()->id : "<none>")
+        + ", selectedBranch=" + processor.getSelectedBranchId();
+}
+
+bool waitUntil(StemhubAudioProcessor& processor, const std::function<bool()>& predicate, int timeoutMs = 3000)
+{
+    const auto deadline = juce::Time::getMillisecondCounter() + static_cast<uint32>(timeoutMs);
+    while (juce::Time::getMillisecondCounter() < deadline)
+    {
+        processor.flushPendingBackgroundResultsForTesting();
+        if (predicate())
+            return true;
+        juce::Thread::sleep(5);
+    }
+
+    processor.flushPendingBackgroundResultsForTesting();
+    return predicate();
+}
+
+class ProcessorChangeWatcher : private juce::ChangeListener
+{
+public:
+    explicit ProcessorChangeWatcher(StemhubAudioProcessor& processor)
+        : processorRef(processor)
+    {
+        processorRef.addChangeListener(this);
+    }
+
+    ~ProcessorChangeWatcher() override
+    {
+        processorRef.removeChangeListener(this);
+    }
+
+private:
+    void changeListenerCallback(juce::ChangeBroadcaster* source) override
+    {
+        juce::ignoreUnused(source);
+    }
+
+    StemhubAudioProcessor& processorRef;
+};
+
+class ProcessorStabilityTests final : public juce::UnitTest
+{
+public:
+    ProcessorStabilityTests()
+        : juce::UnitTest("Stemhub plugin processor stability", "plugin")
+    {
+    }
+
+    void runTest() override
+    {
+        beginTest("Invalid cached session clears cache and returns to login");
+        {
+            TestContext context;
+            context.api->cachedSessionIsValid = false;
+            stemhub::sessioncache::saveAccessToken("expired-token");
+            expect(stemhub::sessioncache::loadAccessToken() == "expired-token", "test cache override should persist saved token");
+
+            context.processor.requestRestoreCachedSession();
+
+            const auto didReachAuthError = waitUntil(context.processor, [&context]
+            {
+                return context.processor.getAuthState() == AuthState::authError;
+            });
+            expect(didReachAuthError, "cached invalid token should end in authError: " + describeProcessorState(context.processor));
+            expect(context.processor.getUIState() == UIState::login, "cached invalid token should leave login UI visible");
+            expect(context.processor.getAuthErrorMessage().containsIgnoreCase("sign in again"),
+                   "cached invalid token should surface re-auth message: " + describeProcessorState(context.processor));
+            expect(stemhub::sessioncache::loadAccessToken().isEmpty(), "cached invalid token should clear saved token");
+        }
+
+        beginTest("Missing cached project falls back to project selection and clears stale context");
+        {
+            TestContext context;
+            context.api->projects = { makeProject("project-2", "Project Two") };
+            stemhub::sessioncache::saveAccessToken("valid-token");
+            stemhub::sessioncache::saveProjectId("missing-project");
+            stemhub::sessioncache::saveLastOpenedProjectFilePath("/tmp/missing.flp");
+            expect(stemhub::sessioncache::loadAccessToken() == "valid-token", "test cache override should persist saved token");
+
+            context.processor.requestRestoreCachedSession();
+
+            const auto didReturnToProjectSelection = waitUntil(context.processor, [&context]
+            {
+                return context.processor.getAuthState() == AuthState::signedIn
+                    && context.processor.getUIState() == UIState::projectSelection
+                    && context.processor.getProjectSelectionStatusMessage().containsIgnoreCase("no longer available");
+            });
+            expect(didReturnToProjectSelection,
+                   "missing cached project should fall back to project selection: " + describeProcessorState(context.processor));
+            expect(!context.processor.getSelectedProject().has_value(), "missing cached project should not select a project");
+            expect(stemhub::sessioncache::loadProjectId().isEmpty(), "missing cached project should clear cached project id");
+            expect(stemhub::sessioncache::loadLastOpenedProjectFilePath().isEmpty(), "missing cached project should clear cached file path");
+        }
+
+        beginTest("Stale project activation results are ignored");
+        {
+            TestContext context;
+            auto projectA = makeProject("project-a", "Project A");
+            auto projectB = makeProject("project-b", "Project B");
+            auto branchA = makeBranch("branch-a", projectA.id, "main");
+            auto branchB = makeBranch("branch-b", projectB.id, "main");
+            context.api->projects = { projectA, projectB };
+            context.api->projectBranches[projectA.id] = { branchA };
+            context.api->projectBranches[projectB.id] = { branchB };
+            context.api->branchVersions[branchA.id] = { makeVersion("aaaaaaaa-0000", branchA.id, "A") };
+            context.api->branchVersions[branchB.id] = { makeVersion("bbbbbbbb-0000", branchB.id, "B") };
+            stemhub::sessioncache::saveAccessToken("valid-token");
+            expect(stemhub::sessioncache::loadAccessToken() == "valid-token", "test cache override should persist saved token");
+            context.processor.requestRestoreCachedSession();
+            const auto didRestoreSession = waitUntil(context.processor, [&context] { return context.processor.getAuthState() == AuthState::signedIn; });
+            expect(didRestoreSession,
+                   "processor should restore valid cached session before open-project race test: " + describeProcessorState(context.processor));
+
+            auto gate = std::make_shared<BlockingGate>();
+            context.api->branchFetchGates[projectA.id] = gate;
+
+            context.processor.requestOpenProject(projectA.id, {}, false);
+            gate->waitUntilEntered();
+
+            context.processor.requestOpenProject(projectB.id, {}, false);
+            expect(waitUntil(context.processor, [&context, &projectB, &branchB]
+            {
+                return context.processor.getSelectedProject().has_value()
+                    && context.processor.getSelectedProject()->id == projectB.id
+                    && context.processor.getSelectedBranchId() == branchB.id;
+            }), "latest open-project request should win");
+
+            gate->release();
+            expect(waitUntil(context.processor, [&context, &projectB, &branchB]
+            {
+                return context.processor.getSelectedProject().has_value()
+                    && context.processor.getSelectedProject()->id == projectB.id
+                    && context.processor.getSelectedBranchId() == branchB.id
+                    && context.processor.getVersionHistory().size() == 1
+                    && context.processor.getVersionHistory().front().branchId == branchB.id;
+            }), "stale open-project result should not overwrite winning selection");
+            gate->waitUntilFinished();
+        }
+
+        beginTest("Stale branch history results are ignored");
+        {
+            TestContext context;
+            auto project = makeProject("project-1", "Project");
+            auto branchMain = makeBranch("branch-main", project.id, "main");
+            auto branchAlt = makeBranch("branch-alt", project.id, "alt");
+            context.api->projects = { project };
+            context.api->projectBranches[project.id] = { branchMain, branchAlt };
+            context.api->branchVersions[branchMain.id] = { makeVersion("11111111-0000", branchMain.id, "main") };
+            context.api->branchVersions[branchAlt.id] = { makeVersion("22222222-0000", branchAlt.id, "alt") };
+            stemhub::sessioncache::saveAccessToken("valid-token");
+            expect(stemhub::sessioncache::loadAccessToken() == "valid-token", "test cache override should persist saved token");
+            context.processor.requestRestoreCachedSession();
+            const auto didRestoreSession = waitUntil(context.processor, [&context] { return context.processor.getAuthState() == AuthState::signedIn; });
+            expect(didRestoreSession,
+                   "processor should restore valid cached session before branch race test: " + describeProcessorState(context.processor));
+            context.processor.requestOpenProject(project.id, {}, false);
+            expect(waitUntil(context.processor, [&context, &branchMain]
+            {
+                return context.processor.getSelectedProject().has_value()
+                    && context.processor.getSelectedBranchId() == branchMain.id;
+            }), "project open should select main branch before branch race test");
+
+            auto gate = std::make_shared<BlockingGate>();
+            context.api->versionFetchGates[branchMain.id] = gate;
+
+            context.processor.requestSelectBranch(branchMain.id);
+            gate->waitUntilEntered();
+
+            context.processor.requestSelectBranch(branchAlt.id);
+            expect(waitUntil(context.processor, [&context, &branchAlt]
+            {
+                return context.processor.getSelectedBranchId() == branchAlt.id
+                    && context.processor.getVersionHistory().size() == 1
+                    && context.processor.getVersionHistory().front().branchId == branchAlt.id;
+            }), "latest branch selection should win");
+
+            gate->release();
+            expect(waitUntil(context.processor, [&context, &branchAlt]
+            {
+                return context.processor.getSelectedBranchId() == branchAlt.id
+                    && context.processor.getVersionHistory().front().branchId == branchAlt.id;
+            }), "stale branch history should not overwrite winning branch");
+            gate->waitUntilFinished();
+        }
+
+        beginTest("Cached project context failure clears stale selection and stays recoverable");
+        {
+            TestContext context;
+            auto project = makeProject("project-1", "Project");
+            context.api->projects = { project };
+            context.api->branchErrors[project.id] = "Failed to load workspaces.";
+            stemhub::sessioncache::saveAccessToken("valid-token");
+            stemhub::sessioncache::saveProjectId(project.id);
+            expect(stemhub::sessioncache::loadAccessToken() == "valid-token", "test cache override should persist saved token");
+
+            context.processor.requestRestoreCachedSession();
+
+            const auto didStayRecoverable = waitUntil(context.processor, [&context]
+            {
+                return context.processor.getAuthState() == AuthState::signedIn
+                    && context.processor.getUIState() == UIState::projectSelection
+                    && context.processor.getOperationState() == OperationState::error;
+            });
+            expect(didStayRecoverable,
+                   "cached project restore failure should remain signed in and recoverable: " + describeProcessorState(context.processor));
+            expect(!context.processor.getSelectedProject().has_value(), "cached project restore failure should not leave a selected project");
+            expect(stemhub::sessioncache::loadProjectId().isEmpty(), "cached project restore failure should clear stale cached project id");
+            expect(context.processor.getProjectSelectionStatusMessage().containsIgnoreCase("Failed to load workspaces"),
+                   "cached project restore failure should surface workspace-load error: " + describeProcessorState(context.processor));
+        }
+    }
+
+private:
+    struct TestContext
+    {
+        TestContext()
+            : tempRoot(juce::File::getSpecialLocation(juce::File::tempDirectory)
+                           .getChildFile("stemhub-plugin-tests")
+                           .getChildFile(juce::Uuid().toString())),
+              cacheFile(tempRoot.getChildFile("session.json")),
+              apiOwned(std::make_unique<FakeProjectApi>()),
+              api(apiOwned.get()),
+              processor(std::move(apiOwned)),
+              watcher(processor)
+        {
+            tempRoot.getParentDirectory().createDirectory();
+            tempRoot.createDirectory();
+            stemhub::sessioncache::setCacheFileOverrideForTesting(cacheFile);
+            stemhub::sessioncache::clear();
+        }
+
+        ~TestContext()
+        {
+            stemhub::sessioncache::clear();
+            stemhub::sessioncache::clearCacheFileOverrideForTesting();
+            tempRoot.deleteRecursively();
+        }
+
+        juce::File tempRoot;
+        juce::File cacheFile;
+        std::unique_ptr<FakeProjectApi> apiOwned;
+        FakeProjectApi* api;
+        StemhubAudioProcessor processor;
+        ProcessorChangeWatcher watcher;
+    };
+};
+
+ProcessorStabilityTests processorStabilityTests;
+}
+
+int main()
+{
+    juce::ScopedJuceInitialiser_GUI scopedJuce;
+    juce::UnitTestRunner runner;
+    runner.setAssertOnFailure(false);
+    runner.runAllTests();
+    int failureCount = 0;
+    for (int i = 0; i < runner.getNumResults(); ++i)
+    {
+        if (auto* result = runner.getResult(i); result != nullptr)
+        {
+            failureCount += result->failures;
+            for (const auto& message : result->messages)
+                juce::Logger::writeToLog(message);
+        }
+    }
+
+    return failureCount == 0 ? 0 : 1;
+}


### PR DESCRIPTION
**Project selection and background job robustness:**

* Introduced a `selectionRequestId` mechanism to track and validate project/branch/version selection requests, ensuring that only results from the latest user-initiated request are applied. This prevents race conditions and stale updates in asynchronous operations. Methods like `beginSelectionRequest()` and `isCurrentSelectionRequest()` were added to `StemhubAudioProcessor`, and all relevant background tasks and results now include and check this ID. [[1]](diffhunk://#diff-4a4307286e47c5a278d550d2ee4b7896e00c78b8b2f9e29f156e869466b5218eR201-R202) [[2]](diffhunk://#diff-4a4307286e47c5a278d550d2ee4b7896e00c78b8b2f9e29f156e869466b5218eR121) [[3]](diffhunk://#diff-4a4307286e47c5a278d550d2ee4b7896e00c78b8b2f9e29f156e869466b5218eR135-R140) [[4]](diffhunk://#diff-ecb34182d381cc58dddd646eb4919d10818e91be81b21ae842411a88ef41e339R37-R44) [[5]](diffhunk://#diff-ecb34182d381cc58dddd646eb4919d10818e91be81b21ae842411a88ef41e339R89-R91) [[6]](diffhunk://#diff-ecb34182d381cc58dddd646eb4919d10818e91be81b21ae842411a88ef41e339R321-R330) [[7]](diffhunk://#diff-ecb34182d381cc58dddd646eb4919d10818e91be81b21ae842411a88ef41e339R418-R433) [[8]](diffhunk://#diff-ecb34182d381cc58dddd646eb4919d10818e91be81b21ae842411a88ef41e339R443-R451) [[9]](diffhunk://#diff-ecb34182d381cc58dddd646eb4919d10818e91be81b21ae842411a88ef41e339R481-R490) [[10]](diffhunk://#diff-ecb34182d381cc58dddd646eb4919d10818e91be81b21ae842411a88ef41e339R515-R525) [[11]](diffhunk://#diff-ecb34182d381cc58dddd646eb4919d10818e91be81b21ae842411a88ef41e339R609-R613)

* Improved error handling and state clearing in project and authentication flows, ensuring that user-facing messages are accurate and the session state is reset appropriately on errors or expired sessions. [[1]](diffhunk://#diff-abc46fe4f8e41e2307266f28ee2cd4f042c86aa06462e5a55dc797d2cf2a2633L18-R28) [[2]](diffhunk://#diff-abc46fe4f8e41e2307266f28ee2cd4f042c86aa06462e5a55dc797d2cf2a2633R162-R177) [[3]](diffhunk://#diff-ecb34182d381cc58dddd646eb4919d10818e91be81b21ae842411a88ef41e339R37-R44)

**Session cache management enhancements:**

* Added new functions to clear specific parts of the session cache (`clearProjectId`, `clearLastOpenedProjectFilePath`, `clearProjectContext`) and to override the cache file location or use in-memory cache for testing. This allows for more precise and testable session state handling. [[1]](diffhunk://#diff-871c9a64611805325865ac0733ea3500cf6555242bcb2713c240b6250418561bR13-R17) [[2]](diffhunk://#diff-5566435195483ff145f1bb32742f1ef1c957aeee0f37882c9f98e057cac6d601R5-R23)

**Automated and headless testing support:**

* Added a new `stemhub_plugin_tests` console application target in CMake, including source and test files, and updated the workflow to build and run these headless tests in CI. The plugin disables the editor in headless test mode. [[1]](diffhunk://#diff-4be91c90d50a581faae28aebd11b94f541d8f2209393690f4f52542a5f909331R77-R121) [[2]](diffhunk://#diff-aaeaf9d9d98ee598ede99f7b7e06fdd264d046e8bf650c42b6eeeb1bd80c63f7R7-R15) [[3]](diffhunk://#diff-aaeaf9d9d98ee598ede99f7b7e06fdd264d046e8bf650c42b6eeeb1bd80c63f7L67-R77) [[4]](diffhunk://#diff-1263b376935d7a2dd8a4c1cb5685694c888048cc3caa5af4cf77bf8f8d30a531R123-R136) [[5]](diffhunk://#diff-1263b376935d7a2dd8a4c1cb5685694c888048cc3caa5af4cf77bf8f8d30a531L145)

**Other improvements:**

* Ensured that the background job coordinator checks for request generation changes both before and after running the task, improving thread safety.
* Added a method to flush pending background results for testing.

These changes collectively improve the reliability, testability, and user experience of the plugin's project/session management and CI process.