### PR TITLE
backend: audit hardening + content-addressed storage foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,10 @@ POSTGRES_DB=stemhub
 PGADMIN_DEFAULT_EMAIL=admin@stemhub.com
 PGADMIN_DEFAULT_PASSWORD=admin
 DATABASE_URL=postgresql+asyncpg://postgres:postgres@db:5432/stemhub
-SECRET_KEY=replace_with_secret
+# SECRET_KEY MUST be at least 32 characters. The backend refuses to boot
+# with a short or known-default value. Generate one with:
+#   python -c 'import secrets; print(secrets.token_urlsafe(48))'
+SECRET_KEY=
 
 NEXT_PUBLIC_API_URL=http://localhost:8000
 FRONTEND_URL=http://localhost:3000

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -119,8 +119,6 @@ jobs:
       POSTGRES_PASSWORD: ci
       POSTGRES_DB: ci
       DATABASE_URL: postgresql://ci:ci@db:5432/ci
-      # Long-enough placeholder to satisfy the SECRET_KEY startup guard
-      # (min 32 chars, rejects known-default strings). CI-only value.
       SECRET_KEY: ci-fixture-secret-key-not-for-any-real-deployment-0123456789
       GOOGLE_CLIENT_ID: ci
       GOOGLE_CLIENT_SECRET: ci

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -119,7 +119,9 @@ jobs:
       POSTGRES_PASSWORD: ci
       POSTGRES_DB: ci
       DATABASE_URL: postgresql://ci:ci@db:5432/ci
-      SECRET_KEY: ci
+      # Long-enough placeholder to satisfy the SECRET_KEY startup guard
+      # (min 32 chars, rejects known-default strings). CI-only value.
+      SECRET_KEY: ci-fixture-secret-key-not-for-any-real-deployment-0123456789
       GOOGLE_CLIENT_ID: ci
       GOOGLE_CLIENT_SECRET: ci
       STEMHUB_STORAGE_PROVIDER: local

--- a/backend/alembic/versions/e3a1c9f2b7d0_add_user_soft_delete.py
+++ b/backend/alembic/versions/e3a1c9f2b7d0_add_user_soft_delete.py
@@ -1,0 +1,29 @@
+"""add_user_soft_delete
+
+Revision ID: e3a1c9f2b7d0
+Revises: c1a2b3d4e5f7
+Create Date: 2026-07-12 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = 'e3a1c9f2b7d0'
+down_revision: Union[str, None] = 'c1a2b3d4e5f7'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('users', sa.Column('is_deleted', sa.Boolean(), server_default='false', nullable=False))
+    op.add_column('users', sa.Column('deleted_at', sa.DateTime(timezone=True), nullable=True))
+    op.create_index(op.f('ix_users_is_deleted'), 'users', ['is_deleted'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_users_is_deleted'), table_name='users')
+    op.drop_column('users', 'deleted_at')
+    op.drop_column('users', 'is_deleted')

--- a/backend/alembic/versions/f7d2c1a48901_add_blob_and_manifest.py
+++ b/backend/alembic/versions/f7d2c1a48901_add_blob_and_manifest.py
@@ -1,0 +1,46 @@
+"""add_blob_and_manifest
+
+Revision ID: f7d2c1a48901
+Revises: e3a1c9f2b7d0
+Create Date: 2026-07-12 00:05:00.000000
+
+Adds content-addressed Blob table (project-scoped) and manifest_json/manifest_version
+columns to Version. See docs/content-addressed-storage.md for the design rationale.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = 'f7d2c1a48901'
+down_revision: Union[str, None] = 'e3a1c9f2b7d0'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'blob',
+        sa.Column('project_id', postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column('sha256', sa.String(length=64), nullable=False),
+        sa.Column('size_bytes', sa.BigInteger(), nullable=False),
+        sa.Column('mime_type', sa.String(length=80), nullable=True),
+        sa.Column('storage_uri', sa.Text(), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=False),
+        sa.Column('ref_count', sa.Integer(), server_default='0', nullable=False),
+        sa.ForeignKeyConstraint(['project_id'], ['project.id'], ondelete='CASCADE'),
+        sa.PrimaryKeyConstraint('project_id', 'sha256'),
+    )
+    op.create_index('ix_blob_ref_count', 'blob', ['ref_count'], unique=False)
+
+    op.add_column('version', sa.Column('manifest_json', postgresql.JSONB(astext_type=sa.Text()), nullable=True))
+    op.add_column('version', sa.Column('manifest_version', sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('version', 'manifest_version')
+    op.drop_column('version', 'manifest_json')
+    op.drop_index('ix_blob_ref_count', table_name='blob')
+    op.drop_table('blob')

--- a/backend/src/stemhub/auth.py
+++ b/backend/src/stemhub/auth.py
@@ -249,7 +249,13 @@ async def get_current_user(request: Request, db: AsyncSession = Depends(get_db))
     except jwt.PyJWTError:
         raise credentials_exception
         
-    result = await db.execute(select(User).where(User.email == email, User.is_active == True))
+    result = await db.execute(
+        select(User).where(
+            User.email == email,
+            User.is_active == True,
+            User.is_deleted == False,
+        )
+    )
     user = result.scalars().first()
     if user is None:
         raise credentials_exception

--- a/backend/src/stemhub/blob_gc.py
+++ b/backend/src/stemhub/blob_gc.py
@@ -1,0 +1,78 @@
+"""Garbage collection for content-addressed blobs.
+
+Blobs with ``ref_count == 0`` and older than the grace window get their
+storage bytes deleted and their DB row removed. The grace window prevents
+races between blob upload (idempotent, by SHA-256) and the subsequent
+version-create call that would increment ref_count.
+
+This module exports a callable. It is NOT a scheduler — wire it into a
+cron job, a background worker, or a manual admin endpoint depending on
+deployment target.
+
+See docs/content-addressed-storage.md.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from .models import Blob
+from .storage import StorageError, StorageService
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_GRACE_HOURS = 24
+
+
+@dataclass(frozen=True)
+class GcResult:
+    scanned: int
+    deleted: int
+    failed: int
+
+
+async def sweep_orphan_blobs(
+    *,
+    db: AsyncSession,
+    storage: StorageService,
+    grace_hours: int = DEFAULT_GRACE_HOURS,
+    batch_size: int = 500,
+) -> GcResult:
+    """Delete blobs with ref_count == 0 older than the grace window.
+
+    Storage bytes are deleted before the DB row so that a mid-sweep crash
+    leaves the DB pointing at real bytes (never the reverse). Failed
+    storage deletions are logged and the DB row is left intact for the
+    next sweep to retry.
+    """
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=grace_hours)
+    result = await db.execute(
+        select(Blob)
+        .where(Blob.ref_count == 0, Blob.created_at < cutoff)
+        .limit(batch_size)
+    )
+    candidates = list(result.scalars().all())
+
+    deleted = 0
+    failed = 0
+    for blob in candidates:
+        try:
+            storage.delete_blob(blob.storage_uri)
+        except StorageError as exc:
+            logger.warning(
+                "gc: failed to delete blob %s/%s from storage: %s",
+                blob.project_id, blob.sha256, exc,
+            )
+            failed += 1
+            continue
+        await db.delete(blob)
+        deleted += 1
+
+    if deleted:
+        await db.commit()
+
+    return GcResult(scanned=len(candidates), deleted=deleted, failed=failed)

--- a/backend/src/stemhub/logging_config.py
+++ b/backend/src/stemhub/logging_config.py
@@ -48,9 +48,20 @@ def configure_logging() -> None:
         logging.getLogger(noisy).setLevel(logging.WARNING)
 
 
+_REQUEST_ID_ALLOWED = set("0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_")
+_REQUEST_ID_MAX_LEN = 64
+
+
+def _sanitize_request_id(raw: str | None) -> str:
+    if not raw:
+        return uuid.uuid4().hex
+    cleaned = "".join(c for c in raw if c in _REQUEST_ID_ALLOWED)[:_REQUEST_ID_MAX_LEN]
+    return cleaned or uuid.uuid4().hex
+
+
 class RequestIdMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
-        rid = request.headers.get("x-request-id") or uuid.uuid4().hex
+        rid = _sanitize_request_id(request.headers.get("x-request-id"))
         token = _request_id.set(rid)
         started = time.perf_counter()
         response: Response | None = None

--- a/backend/src/stemhub/logging_config.py
+++ b/backend/src/stemhub/logging_config.py
@@ -1,0 +1,75 @@
+"""Structured JSON logging + request-id middleware.
+
+Keeps a stdlib-only implementation to avoid adding new runtime dependencies at alpha.
+"""
+import json
+import logging
+import os
+import time
+import uuid
+from contextvars import ContextVar
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+_request_id: ContextVar[str] = ContextVar("request_id", default="-")
+
+
+class JsonFormatter(logging.Formatter):
+    def format(self, record: logging.LogRecord) -> str:
+        payload = {
+            "ts": self.formatTime(record, "%Y-%m-%dT%H:%M:%S%z"),
+            "level": record.levelname,
+            "logger": record.name,
+            "msg": record.getMessage(),
+            "request_id": _request_id.get(),
+        }
+        if record.exc_info:
+            payload["exc"] = self.formatException(record.exc_info)
+        for key in ("path", "method", "status", "duration_ms"):
+            value = getattr(record, key, None)
+            if value is not None:
+                payload[key] = value
+        return json.dumps(payload)
+
+
+def configure_logging() -> None:
+    level = os.getenv("LOG_LEVEL", "INFO").upper()
+    handler = logging.StreamHandler()
+    handler.setFormatter(JsonFormatter())
+
+    root = logging.getLogger()
+    root.handlers = [handler]
+    root.setLevel(level)
+
+    # Silence noisy loggers unless explicitly overridden.
+    for noisy in ("uvicorn.access",):
+        logging.getLogger(noisy).setLevel(logging.WARNING)
+
+
+class RequestIdMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next):
+        rid = request.headers.get("x-request-id") or uuid.uuid4().hex
+        token = _request_id.set(rid)
+        started = time.perf_counter()
+        response: Response | None = None
+        status_code = 500
+        try:
+            response = await call_next(request)
+            status_code = response.status_code
+            return response
+        finally:
+            duration_ms = int((time.perf_counter() - started) * 1000)
+            logging.getLogger("stemhub.request").info(
+                "request",
+                extra={
+                    "path": request.url.path,
+                    "method": request.method,
+                    "status": status_code,
+                    "duration_ms": duration_ms,
+                },
+            )
+            if response is not None:
+                response.headers["X-Request-ID"] = rid
+            _request_id.reset(token)

--- a/backend/src/stemhub/main.py
+++ b/backend/src/stemhub/main.py
@@ -92,7 +92,9 @@ async def ready():
         async with engine.connect() as conn:
             await conn.execute(text("SELECT 1"))
         return {"status": "ready"}
-    except Exception as exc:
-        logger.warning("readiness check failed: %s", exc)
+    except Exception:
+        # Log the real exception server-side; don't leak it to callers,
+        # since it can contain DB connection strings or internal hostnames.
+        logger.exception("readiness check failed")
         from fastapi.responses import JSONResponse
-        return JSONResponse(status_code=503, content={"status": "not_ready", "detail": str(exc)})
+        return JSONResponse(status_code=503, content={"status": "not_ready", "detail": "database unavailable"})

--- a/backend/src/stemhub/main.py
+++ b/backend/src/stemhub/main.py
@@ -1,6 +1,8 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from sqlalchemy import text
 import os
+import logging
 from contextlib import asynccontextmanager
 from .auth import router as auth_router
 from .routers.files import router as files_router
@@ -12,9 +14,14 @@ from .routers.stats import router as stats_router
 from .routers.admin import router as admin_router
 from .routers.explore import router as explore_router
 from .routers.community import router as community_router
-from .routers.admin import router as admin_router
+from .routers.blobs import router as blobs_router
 from .database import engine
 from .migrations import check_migrations_async
+from .logging_config import RequestIdMiddleware, configure_logging
+
+configure_logging()
+logger = logging.getLogger(__name__)
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
@@ -23,10 +30,9 @@ async def lifespan(app: FastAPI):
     try:
         await check_migrations_async()
     except Exception as e:
-        import logging
-        logging.getLogger(__name__).error(f"Startup failed due to pending migrations: {e}")
+        logger.error(f"Startup failed due to pending migrations: {e}")
         raise RuntimeError("Pending migrations found. Please run 'alembic upgrade head' before starting the application.") from e
-        
+
     yield
 
 app = FastAPI(title="StemHub API", lifespan=lifespan)
@@ -55,6 +61,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+app.add_middleware(RequestIdMiddleware)
 
 app.include_router(auth_router)
 app.include_router(projects_router)
@@ -66,8 +73,26 @@ app.include_router(stats_router)
 app.include_router(admin_router)
 app.include_router(explore_router)
 app.include_router(community_router)
-app.include_router(admin_router)
+app.include_router(blobs_router)
+
 
 @app.get("/")
 async def root():
     return {"message": "Welcome to the StemHub API"}
+
+
+@app.get("/health")
+async def health():
+    return {"status": "ok"}
+
+
+@app.get("/ready")
+async def ready():
+    try:
+        async with engine.connect() as conn:
+            await conn.execute(text("SELECT 1"))
+        return {"status": "ready"}
+    except Exception as exc:
+        logger.warning("readiness check failed: %s", exc)
+        from fastapi.responses import JSONResponse
+        return JSONResponse(status_code=503, content={"status": "not_ready", "detail": str(exc)})

--- a/backend/src/stemhub/models.py
+++ b/backend/src/stemhub/models.py
@@ -98,12 +98,27 @@ class Version(Base):
     source_daw: Mapped[str | None] = mapped_column(String(50), nullable=True)
     source_project_filename: Mapped[str | None] = mapped_column(String(255), nullable=True)
     snapshot_manifest: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    manifest_json: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    manifest_version: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
     # ── Relationships ──
     branch: Mapped["Branch"] = relationship("Branch", back_populates="versions")
     author: Mapped["User | None"] = relationship("User", foreign_keys=[created_by])
     parent: Mapped["Version | None"] = relationship("Version", remote_side="Version.id", backref="children")
     tracks: Mapped[list["Track"]] = relationship("Track", back_populates="version")
+
+
+class Blob(Base):
+    """Content-addressed blob. Project-scoped for privacy — see docs/content-addressed-storage.md."""
+    __tablename__ = "blob"
+
+    project_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("project.id", ondelete="CASCADE"), primary_key=True)
+    sha256: Mapped[str] = mapped_column(String(64), primary_key=True)
+    size_bytes: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    mime_type: Mapped[str | None] = mapped_column(String(80), nullable=True)
+    storage_uri: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
+    ref_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
 
 
 class Track(Base):

--- a/backend/src/stemhub/models.py
+++ b/backend/src/stemhub/models.py
@@ -24,6 +24,8 @@ class User(Base):
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
     is_admin: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    is_deleted: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False, index=True)
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
 
     # ── Relationships ──
     projects: Mapped[list["Project"]] = relationship("Project", back_populates="owner")

--- a/backend/src/stemhub/models.py
+++ b/backend/src/stemhub/models.py
@@ -97,7 +97,17 @@ class Version(Base):
     artifact_checksum: Mapped[str | None] = mapped_column(String(128), nullable=True)  # SHA-256 for integrity verification
     source_daw: Mapped[str | None] = mapped_column(String(50), nullable=True)
     source_project_filename: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    # ── Version payload ──
+    # snapshot_manifest is the legacy field: it stores the DAW mixer state that
+    # was extracted from the (whole) artifact bundle uploaded via the old flow.
+    # It will keep being written by the legacy POST /versions endpoint until
+    # the plugin migrates to the manifest-based flow.
     snapshot_manifest: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
+    # manifest_json is the content-addressed manifest (see
+    # docs/content-addressed-storage.md). Populated only by the new
+    # manifest-based version-create endpoint. When set, artifact_path /
+    # artifact_size_bytes / artifact_checksum are unused. manifest_version
+    # is the schema version of this JSON blob so future readers can migrate.
     manifest_json: Mapped[dict[str, Any] | None] = mapped_column(JSONB, nullable=True)
     manifest_version: Mapped[int | None] = mapped_column(Integer, nullable=True)
 

--- a/backend/src/stemhub/routers/_project_access.py
+++ b/backend/src/stemhub/routers/_project_access.py
@@ -1,0 +1,82 @@
+"""Shared project-access helpers for routers.
+
+Two variants matter:
+
+- ``get_project_with_write_access``: for endpoints that mutate project data
+  (blob uploads, version creates). Owner or collaborator with role in
+  {Admin, Editor}. Returns 404 on miss to avoid confirming project existence
+  to non-members.
+
+- ``get_project_with_read_access``: for endpoints that read project data.
+  Public projects are readable by any authenticated user. Otherwise: owner
+  or any collaborator. Also 404 on miss.
+
+Both use 404 (privacy-hiding) rather than 403. This diverges from
+``projects.py::_get_project_with_access`` which returns 403; that helper
+predates this module and is left in place for now.
+"""
+from uuid import UUID
+
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from stemhub.models import Collaborator, Project, User
+
+
+_WRITE_ROLES = ("Admin", "Editor")
+
+
+async def get_project_with_write_access(
+    *, project_id: UUID, current_user: User, db: AsyncSession
+) -> Project:
+    result = await db.execute(
+        select(Project).where(
+            Project.id == project_id,
+            Project.is_deleted == False,
+        )
+    )
+    project = result.scalar_one_or_none()
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    if project.owner_id == current_user.id:
+        return project
+
+    collab = await db.execute(
+        select(Collaborator).where(
+            Collaborator.project_id == project.id,
+            Collaborator.user_id == current_user.id,
+            Collaborator.role.in_(_WRITE_ROLES),
+        )
+    )
+    if collab.scalars().first() is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    return project
+
+
+async def get_project_with_read_access(
+    *, project_id: UUID, current_user: User, db: AsyncSession
+) -> Project:
+    result = await db.execute(
+        select(Project).where(
+            Project.id == project_id,
+            Project.is_deleted == False,
+        )
+    )
+    project = result.scalar_one_or_none()
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    if project.is_public or project.owner_id == current_user.id:
+        return project
+
+    collab = await db.execute(
+        select(Collaborator).where(
+            Collaborator.project_id == project.id,
+            Collaborator.user_id == current_user.id,
+        )
+    )
+    if collab.scalars().first() is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    return project

--- a/backend/src/stemhub/routers/admin.py
+++ b/backend/src/stemhub/routers/admin.py
@@ -7,9 +7,11 @@ from sqlalchemy.future import select
 from sqlalchemy import func, cast, Date
 
 from ..auth import get_current_admin_user
+from ..blob_gc import sweep_orphan_blobs
 from ..database import get_db
 from ..models import Project, User
 from ..schemas import UserResponse, DailySignup, AdminStats, UserWithProjects, RecentUser
+from ..storage import StorageService, get_storage_service
 
 router = APIRouter(prefix="/api/admin", tags=["admin"])
 
@@ -129,3 +131,32 @@ async def toggle_active(
     await db.commit()
     await db.refresh(user)
     return user
+
+
+@router.post("/blobs/gc")
+async def run_blob_gc(
+    _: User = Depends(get_current_admin_user),
+    db: AsyncSession = Depends(get_db),
+    storage: StorageService = Depends(get_storage_service),
+    grace_hours: int = Query(24, ge=0, le=720),
+    batch_size: int = Query(500, ge=1, le=5000),
+):
+    """Run one pass of the content-addressed blob GC sweep.
+
+    Deletes blobs where ref_count == 0 and older than the grace window.
+    See docs/content-addressed-storage.md. Intended to be invoked by an
+    external scheduler; also usable ad-hoc from an admin session.
+    """
+    result = await sweep_orphan_blobs(
+        db=db,
+        storage=storage,
+        grace_hours=grace_hours,
+        batch_size=batch_size,
+    )
+    return {
+        "scanned": result.scanned,
+        "deleted": result.deleted,
+        "failed": result.failed,
+        "grace_hours": grace_hours,
+        "batch_size": batch_size,
+    }

--- a/backend/src/stemhub/routers/blobs.py
+++ b/backend/src/stemhub/routers/blobs.py
@@ -5,7 +5,7 @@ See docs/content-addressed-storage.md for the design rationale.
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, RedirectResponse
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
@@ -147,6 +147,12 @@ async def download_blob(
     blob = result.scalar_one_or_none()
     if blob is None:
         raise HTTPException(status_code=404, detail="Blob not found")
+
+    # Backends that support presigned URLs (e.g. GCS) return one and we
+    # redirect the client to it — bytes never flow through the API server.
+    presigned = storage.get_blob_download_url(blob.storage_uri)
+    if presigned is not None:
+        return RedirectResponse(url=presigned, status_code=307)
 
     try:
         path = storage.resolve_blob_path(blob.storage_uri)

--- a/backend/src/stemhub/routers/blobs.py
+++ b/backend/src/stemhub/routers/blobs.py
@@ -1,0 +1,202 @@
+"""Content-addressed blob endpoints.
+
+See docs/content-addressed-storage.md for the design rationale.
+"""
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
+from fastapi.responses import FileResponse
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from stemhub.auth import get_current_user
+from stemhub.database import get_db
+from stemhub.models import Blob, Collaborator, Project, User
+from stemhub.storage import StorageNotFoundError, StorageService, get_storage_service
+
+router = APIRouter(prefix="/projects/{project_id}/blobs", tags=["blobs"])
+
+
+class CheckMissingRequest(BaseModel):
+    sha256s: list[str]
+
+
+class CheckMissingResponse(BaseModel):
+    missing: list[str]
+
+
+class BlobResponse(BaseModel):
+    sha256: str
+    size_bytes: int
+    mime_type: str | None = None
+
+
+async def _get_project_with_write_access(
+    *, project_id: UUID, current_user: User, db: AsyncSession
+) -> Project:
+    result = await db.execute(
+        select(Project).where(
+            Project.id == project_id,
+            Project.is_deleted == False,
+        )
+    )
+    project = result.scalar_one_or_none()
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    if project.owner_id == current_user.id:
+        return project
+
+    collab = await db.execute(
+        select(Collaborator).where(
+            Collaborator.project_id == project.id,
+            Collaborator.user_id == current_user.id,
+            Collaborator.role.in_(["Admin", "Editor"]),
+        )
+    )
+    if collab.scalars().first() is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    return project
+
+
+async def _get_project_with_read_access(
+    *, project_id: UUID, current_user: User, db: AsyncSession
+) -> Project:
+    result = await db.execute(
+        select(Project).where(
+            Project.id == project_id,
+            Project.is_deleted == False,
+        )
+    )
+    project = result.scalar_one_or_none()
+    if project is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    if project.is_public or project.owner_id == current_user.id:
+        return project
+
+    collab = await db.execute(
+        select(Collaborator).where(
+            Collaborator.project_id == project.id,
+            Collaborator.user_id == current_user.id,
+        )
+    )
+    if collab.scalars().first() is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    return project
+
+
+def _validate_sha256(candidate: str) -> str:
+    normalized = candidate.strip().lower()
+    if len(normalized) != 64 or any(c not in "0123456789abcdef" for c in normalized):
+        raise HTTPException(status_code=400, detail=f"Invalid sha256: {candidate!r}")
+    return normalized
+
+
+@router.post("/check-missing", response_model=CheckMissingResponse)
+async def check_missing(
+    project_id: UUID,
+    payload: CheckMissingRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> CheckMissingResponse:
+    await _get_project_with_write_access(
+        project_id=project_id, current_user=current_user, db=db
+    )
+    requested = [_validate_sha256(s) for s in payload.sha256s]
+    if not requested:
+        return CheckMissingResponse(missing=[])
+
+    result = await db.execute(
+        select(Blob.sha256).where(
+            Blob.project_id == project_id,
+            Blob.sha256.in_(requested),
+        )
+    )
+    present = {row[0] for row in result.all()}
+    return CheckMissingResponse(missing=[s for s in requested if s not in present])
+
+
+@router.put("/{sha256}", response_model=BlobResponse)
+async def upload_blob(
+    project_id: UUID,
+    sha256: str,
+    file: UploadFile = File(...),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    storage: StorageService = Depends(get_storage_service),
+) -> BlobResponse:
+    expected_sha = _validate_sha256(sha256)
+    await _get_project_with_write_access(
+        project_id=project_id, current_user=current_user, db=db
+    )
+
+    existing = await db.execute(
+        select(Blob).where(Blob.project_id == project_id, Blob.sha256 == expected_sha)
+    )
+    existing_blob = existing.scalar_one_or_none()
+    if existing_blob is not None:
+        return BlobResponse(
+            sha256=existing_blob.sha256,
+            size_bytes=existing_blob.size_bytes,
+            mime_type=existing_blob.mime_type,
+        )
+
+    stored = storage.store_blob(project_id=project_id, source=file.file)
+    if stored.checksum_sha256 != expected_sha:
+        # Integrity mismatch: client claimed X, bytes hashed to Y.
+        storage.delete_blob(stored.path)
+        raise HTTPException(
+            status_code=400,
+            detail=f"sha256 mismatch: expected {expected_sha}, got {stored.checksum_sha256}",
+        )
+
+    blob = Blob(
+        project_id=project_id,
+        sha256=expected_sha,
+        size_bytes=stored.size_bytes,
+        mime_type=file.content_type,
+        storage_uri=stored.path,
+        ref_count=0,
+    )
+    db.add(blob)
+    await db.commit()
+
+    return BlobResponse(
+        sha256=blob.sha256,
+        size_bytes=blob.size_bytes,
+        mime_type=blob.mime_type,
+    )
+
+
+@router.get("/{sha256}")
+async def download_blob(
+    project_id: UUID,
+    sha256: str,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+    storage: StorageService = Depends(get_storage_service),
+):
+    expected_sha = _validate_sha256(sha256)
+    await _get_project_with_read_access(
+        project_id=project_id, current_user=current_user, db=db
+    )
+
+    result = await db.execute(
+        select(Blob).where(Blob.project_id == project_id, Blob.sha256 == expected_sha)
+    )
+    blob = result.scalar_one_or_none()
+    if blob is None:
+        raise HTTPException(status_code=404, detail="Blob not found")
+
+    try:
+        path = storage.resolve_blob_path(blob.storage_uri)
+    except StorageNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+    return FileResponse(
+        path=str(path),
+        media_type=blob.mime_type or "application/octet-stream",
+        headers={"X-Blob-SHA256": blob.sha256},
+    )

--- a/backend/src/stemhub/routers/blobs.py
+++ b/backend/src/stemhub/routers/blobs.py
@@ -4,22 +4,31 @@ See docs/content-addressed-storage.md for the design rationale.
 """
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, status
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from fastapi.responses import FileResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.future import select
 
 from stemhub.auth import get_current_user
 from stemhub.database import get_db
-from stemhub.models import Blob, Collaborator, Project, User
+from stemhub.models import Blob, User
 from stemhub.storage import StorageNotFoundError, StorageService, get_storage_service
+
+from ._project_access import (
+    get_project_with_read_access,
+    get_project_with_write_access,
+)
 
 router = APIRouter(prefix="/projects/{project_id}/blobs", tags=["blobs"])
 
+# Cap on how many sha256s a client can query per check-missing request.
+# Prevents an unbounded IN (...) query from a single request.
+CHECK_MISSING_MAX_ITEMS = 1000
+
 
 class CheckMissingRequest(BaseModel):
-    sha256s: list[str]
+    sha256s: list[str] = Field(default_factory=list, max_length=CHECK_MISSING_MAX_ITEMS)
 
 
 class CheckMissingResponse(BaseModel):
@@ -30,61 +39,6 @@ class BlobResponse(BaseModel):
     sha256: str
     size_bytes: int
     mime_type: str | None = None
-
-
-async def _get_project_with_write_access(
-    *, project_id: UUID, current_user: User, db: AsyncSession
-) -> Project:
-    result = await db.execute(
-        select(Project).where(
-            Project.id == project_id,
-            Project.is_deleted == False,
-        )
-    )
-    project = result.scalar_one_or_none()
-    if project is None:
-        raise HTTPException(status_code=404, detail="Project not found")
-
-    if project.owner_id == current_user.id:
-        return project
-
-    collab = await db.execute(
-        select(Collaborator).where(
-            Collaborator.project_id == project.id,
-            Collaborator.user_id == current_user.id,
-            Collaborator.role.in_(["Admin", "Editor"]),
-        )
-    )
-    if collab.scalars().first() is None:
-        raise HTTPException(status_code=404, detail="Project not found")
-    return project
-
-
-async def _get_project_with_read_access(
-    *, project_id: UUID, current_user: User, db: AsyncSession
-) -> Project:
-    result = await db.execute(
-        select(Project).where(
-            Project.id == project_id,
-            Project.is_deleted == False,
-        )
-    )
-    project = result.scalar_one_or_none()
-    if project is None:
-        raise HTTPException(status_code=404, detail="Project not found")
-
-    if project.is_public or project.owner_id == current_user.id:
-        return project
-
-    collab = await db.execute(
-        select(Collaborator).where(
-            Collaborator.project_id == project.id,
-            Collaborator.user_id == current_user.id,
-        )
-    )
-    if collab.scalars().first() is None:
-        raise HTTPException(status_code=404, detail="Project not found")
-    return project
 
 
 def _validate_sha256(candidate: str) -> str:
@@ -101,7 +55,7 @@ async def check_missing(
     current_user: User = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> CheckMissingResponse:
-    await _get_project_with_write_access(
+    await get_project_with_write_access(
         project_id=project_id, current_user=current_user, db=db
     )
     requested = [_validate_sha256(s) for s in payload.sha256s]
@@ -128,7 +82,7 @@ async def upload_blob(
     storage: StorageService = Depends(get_storage_service),
 ) -> BlobResponse:
     expected_sha = _validate_sha256(sha256)
-    await _get_project_with_write_access(
+    await get_project_with_write_access(
         project_id=project_id, current_user=current_user, db=db
     )
 
@@ -143,9 +97,13 @@ async def upload_blob(
             mime_type=existing_blob.mime_type,
         )
 
+    # Write bytes to storage first, then the DB row. If the process dies between
+    # the two steps, the storage object is orphaned (no DB row references it).
+    # This is acceptable: the GC sweep for blobs with ref_count == 0 (see
+    # docs/content-addressed-storage.md) will reclaim it after the grace window.
+    # The reverse order (DB first) would produce 404s on download and is worse.
     stored = storage.store_blob(project_id=project_id, source=file.file)
     if stored.checksum_sha256 != expected_sha:
-        # Integrity mismatch: client claimed X, bytes hashed to Y.
         storage.delete_blob(stored.path)
         raise HTTPException(
             status_code=400,
@@ -179,7 +137,7 @@ async def download_blob(
     storage: StorageService = Depends(get_storage_service),
 ):
     expected_sha = _validate_sha256(sha256)
-    await _get_project_with_read_access(
+    await get_project_with_read_access(
         project_id=project_id, current_user=current_user, db=db
     )
 

--- a/backend/src/stemhub/routers/versions.py
+++ b/backend/src/stemhub/routers/versions.py
@@ -8,7 +8,7 @@ from sqlalchemy.future import select
 from sqlalchemy.orm import selectinload
 
 from stemhub.database import get_db
-from stemhub.models import Collaborator, Version, Branch, Project, User
+from stemhub.models import Blob, Collaborator, Version, Branch, Project, User
 from stemhub.schemas import (
     MixerDiffChange,
     MixerDiffResponse,
@@ -16,6 +16,7 @@ from stemhub.schemas import (
     OwnerSummary,
     VersionCreate,
     VersionDiffHistoryEntry,
+    VersionFromManifestCreate,
     VersionResponse,
     VersionWithAuthor,
 )
@@ -24,6 +25,26 @@ from stemhub.flp_mixer_snapshot import MixerSnapshotError, diff_mixer_project_sn
 from stemhub.storage import StorageError, StorageService, get_storage_service
 
 router = APIRouter(tags=["versions"])
+
+
+def _extract_manifest_blob_shas(manifest: dict) -> set[str]:
+    """Return every sha256 referenced by a v1 manifest.
+
+    Defensive: reads only the fields we know about and skips anything else.
+    Callers should already have validated the manifest at write time.
+    """
+    shas: set[str] = set()
+    project_file = manifest.get("project_file") or {}
+    if isinstance(project_file, dict):
+        sha = project_file.get("sha256")
+        if isinstance(sha, str):
+            shas.add(sha)
+    for track in manifest.get("tracks") or []:
+        if isinstance(track, dict):
+            sha = track.get("sha256")
+            if isinstance(sha, str):
+                shas.add(sha)
+    return shas
 
 
 async def _can_access_project(
@@ -188,6 +209,80 @@ async def create_version(
     await db.commit()
     await db.refresh(db_version)
     return db_version
+
+
+@router.post(
+    "/branches/{branch_id}/versions/from-manifest",
+    response_model=VersionResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_version_from_manifest(
+    branch_id: UUID,
+    payload: VersionFromManifestCreate,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """Create a new version by referencing already-uploaded blobs.
+
+    The manifest lists SHA-256 hashes for the project file and every track.
+    All referenced blobs must already exist in the project (uploaded via
+    PUT /projects/{pid}/blobs/{sha256}). ref_count is bumped atomically
+    with the Version row insert.
+
+    See docs/content-addressed-storage.md.
+    """
+    result = await db.execute(
+        select(Branch).join(Project).where(
+            Branch.id == branch_id,
+            Branch.is_deleted == False,
+            Project.is_deleted == False,
+        )
+    )
+    branch = result.scalars().first()
+    if branch is None:
+        raise HTTPException(status_code=404, detail="Branch not found or you don't have access")
+    if not await _can_access_project(project_id=branch.project_id, current_user=current_user, db=db):
+        raise HTTPException(status_code=404, detail="Branch not found or you don't have access")
+
+    manifest = payload.manifest
+    required_shas = manifest.all_blob_shas()
+
+    existing_result = await db.execute(
+        select(Blob).where(
+            Blob.project_id == branch.project_id,
+            Blob.sha256.in_(required_shas),
+        )
+    )
+    existing_blobs = list(existing_result.scalars().all())
+    existing_shas = {b.sha256 for b in existing_blobs}
+    missing = required_shas - existing_shas
+    if missing:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "error": "missing_blobs",
+                "missing": sorted(missing),
+            },
+        )
+
+    for blob in existing_blobs:
+        blob.ref_count = blob.ref_count + 1
+
+    db_version = Version(
+        branch_id=branch_id,
+        created_by=current_user.id,
+        commit_message=payload.commit_message,
+        parent_version_id=payload.parent_version_id,
+        source_daw=manifest.source_daw,
+        source_project_filename=manifest.source_project_filename,
+        manifest_json=manifest.model_dump(mode="json"),
+        manifest_version=manifest.manifest_version,
+    )
+    db.add(db_version)
+    await db.commit()
+    await db.refresh(db_version)
+    return db_version
+
 
 @router.get("/branches/{branch_id}/versions/", response_model=List[VersionResponse])
 async def list_versions(
@@ -408,7 +503,7 @@ async def delete_version(
     Delete a version.
     """
     result = await db.execute(
-        select(Version).join(Branch).join(Project).where(
+        select(Version, Branch.project_id).join(Branch, Version.branch_id == Branch.id).join(Project, Branch.project_id == Project.id).where(
             Version.id == version_id,
             Project.owner_id == current_user.id,
             Version.is_deleted == False,
@@ -416,9 +511,29 @@ async def delete_version(
             Project.is_deleted == False
         )
     )
-    version = result.scalars().first()
-    if not version:
+    row = result.first()
+    if not row:
         raise HTTPException(status_code=404, detail="Version not found")
+    version, project_id = row
+
+    # If this is a CAS version, decrement ref_count on each referenced blob.
+    # Blobs whose ref_count drops to 0 will be reclaimed by the GC sweep after
+    # the grace window (see docs/content-addressed-storage.md).
+    if version.manifest_json:
+        try:
+            referenced_shas = _extract_manifest_blob_shas(version.manifest_json)
+        except (KeyError, TypeError):
+            referenced_shas = set()
+        if referenced_shas:
+            blob_result = await db.execute(
+                select(Blob).where(
+                    Blob.project_id == project_id,
+                    Blob.sha256.in_(referenced_shas),
+                )
+            )
+            for blob in blob_result.scalars().all():
+                if blob.ref_count > 0:
+                    blob.ref_count = blob.ref_count - 1
 
     version.is_deleted = True
     version.deleted_at = datetime.now(timezone.utc)

--- a/backend/src/stemhub/schemas.py
+++ b/backend/src/stemhub/schemas.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Any, Literal, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, EmailStr
+from pydantic import BaseModel, EmailStr, Field, field_validator
 
 # ── User Schemas ──
 
@@ -98,6 +98,8 @@ class VersionBase(BaseModel):
     source_daw: Optional[str] = None
     source_project_filename: Optional[str] = None
     snapshot_manifest: Optional[dict[str, Any]] = None
+    manifest_json: Optional[dict[str, Any]] = None
+    manifest_version: Optional[int] = None
 
 class VersionCreate(VersionBase):
     pass
@@ -113,6 +115,49 @@ class VersionResponse(VersionBase):
 
     class Config:
         from_attributes = True
+
+
+# ── Content-Addressed Manifest (v1) ──
+#
+# See docs/content-addressed-storage.md. Every blob reference is a hex
+# SHA-256 that must already exist in the project's blob table (uploaded
+# via PUT /projects/{pid}/blobs/{sha256}) before a version can reference it.
+
+_SHA256_HEX_RE = "^[0-9a-f]{64}$"
+
+
+class ManifestBlobRef(BaseModel):
+    sha256: str = Field(pattern=_SHA256_HEX_RE)
+    size_bytes: int = Field(ge=0)
+    filename: str = Field(min_length=1, max_length=255)
+
+
+class ManifestTrack(ManifestBlobRef):
+    name: str = Field(min_length=1, max_length=255)
+    bpm: Optional[int] = Field(default=None, ge=1, le=1000)
+    key: Optional[str] = Field(default=None, max_length=10)
+    duration_seconds: Optional[int] = Field(default=None, ge=0)
+
+
+class VersionManifestV1(BaseModel):
+    manifest_version: Literal[1] = 1
+    source_daw: Optional[str] = Field(default=None, max_length=50)
+    source_project_filename: Optional[str] = Field(default=None, max_length=255)
+    project_file: ManifestBlobRef
+    tracks: list[ManifestTrack] = Field(default_factory=list, max_length=500)
+    mixer_state: Optional[dict[str, Any]] = None
+
+    def all_blob_shas(self) -> set[str]:
+        shas = {self.project_file.sha256}
+        shas.update(t.sha256 for t in self.tracks)
+        return shas
+
+
+class VersionFromManifestCreate(BaseModel):
+    commit_message: Optional[str] = Field(default=None, max_length=500)
+    parent_version_id: Optional[UUID] = None
+    manifest: VersionManifestV1
+
 
 # ── Collaborator Schemas ──
 

--- a/backend/src/stemhub/security.py
+++ b/backend/src/stemhub/security.py
@@ -3,9 +3,28 @@ import bcrypt
 import jwt
 from datetime import datetime, timedelta, timezone
 
-SECRET_KEY = os.getenv("SECRET_KEY", "temporary-secret-key-change-it")
+_INSECURE_DEFAULTS = {"", "temporary-secret-key-change-it", "replace_with_secret", "changeme"}
+
+
+def _load_secret_key() -> str:
+    key = (os.getenv("SECRET_KEY") or "").strip()
+    if key in _INSECURE_DEFAULTS:
+        raise RuntimeError(
+            "SECRET_KEY environment variable must be set to a strong, non-default value "
+            "(minimum 32 characters). Refusing to start with an insecure default."
+        )
+    if len(key) < 32:
+        raise RuntimeError(
+            "SECRET_KEY must be at least 32 characters long. Generate one with "
+            "`python -c 'import secrets; print(secrets.token_urlsafe(48))'`."
+        )
+    return key
+
+
+SECRET_KEY = _load_secret_key()
 ALGORITHM = "HS256"
-ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 24 * 7  # 7 days
+ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 24  # 24 hours
+
 
 def verify_password(plain_password: str, password_hash: str) -> bool:
     try:
@@ -13,9 +32,11 @@ def verify_password(plain_password: str, password_hash: str) -> bool:
     except ValueError:
         return False
 
+
 def get_password_hash(password: str) -> str:
     salt = bcrypt.gensalt()
     return bcrypt.hashpw(password.encode('utf-8'), salt).decode('utf-8')
+
 
 def create_access_token(data: dict) -> str:
     to_encode = data.copy()

--- a/backend/src/stemhub/storage.py
+++ b/backend/src/stemhub/storage.py
@@ -300,9 +300,11 @@ class GCSStorageService(StorageService):
         try:
             blob_path = self._build_blob_path(project_id, checksum_sha256)
             gcs_blob = self._bucket.blob(blob_path)
-            if not gcs_blob.exists():
-                with tmp_path.open("rb") as upload_source:
-                    gcs_blob.upload_from_file(upload_source, size=size_bytes)
+            # No pre-check via exists(): the DB-level idempotency check in the
+            # blobs router already gates duplicate uploads. Overwriting with
+            # identical bytes is safe (content-addressed by SHA-256).
+            with tmp_path.open("rb") as upload_source:
+                gcs_blob.upload_from_file(upload_source, size=size_bytes)
         finally:
             tmp_path.unlink(missing_ok=True)
 

--- a/backend/src/stemhub/storage.py
+++ b/backend/src/stemhub/storage.py
@@ -59,6 +59,24 @@ def _write_stream_and_hash(source: BinaryIO, destination: Path) -> tuple[int, st
     return size_bytes, checksum.hexdigest()
 
 
+def _hash_stream_to_tempfile(source: BinaryIO) -> tuple[Path, int, str]:
+    checksum = hashlib.sha256()
+    size_bytes = 0
+
+    fd, temp_path = tempfile.mkstemp(prefix="stemhub-upload-")
+    tmp = Path(temp_path)
+    with os.fdopen(fd, "wb") as output:
+        while True:
+            chunk = source.read(1024 * 1024)
+            if not chunk:
+                break
+            checksum.update(chunk)
+            size_bytes += len(chunk)
+            output.write(chunk)
+
+    return tmp, size_bytes, checksum.hexdigest()
+
+
 def _delete_files_in_directory(directory: Path) -> bool:
     if not directory.is_dir():
         return False
@@ -110,6 +128,26 @@ class StorageService(ABC):
     def delete_project_preview(self, project_id: UUID) -> bool:
         raise NotImplementedError
 
+    # ── Content-addressed blob operations ──
+
+    @abstractmethod
+    def store_blob(
+        self,
+        *,
+        project_id: UUID,
+        source: BinaryIO,
+    ) -> StoredArtifact:
+        """Store a blob and return its SHA-256, size, and storage_uri (StoredArtifact.path)."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def resolve_blob_path(self, storage_uri: str) -> Path:
+        raise NotImplementedError
+
+    @abstractmethod
+    def delete_blob(self, storage_uri: str) -> bool:
+        raise NotImplementedError
+
 
 class GCSStorageService(StorageService):
     _GCS_SCHEME = "gcs://"
@@ -156,20 +194,18 @@ class GCSStorageService(StorageService):
         artifact_path = self._build_artifact_path(project_id, branch_id, version_id, safe_filename)
 
         _rewind_if_possible(source)
-
-        blob = self._bucket.blob(artifact_path)
-        
-        # Stream the file-like object directly to Google Cloud Storage
-        # This completely avoids writing the file to the local disk.
-        blob.upload_from_file(source)
-        
-        # Reload to get the size and hash computed by GCS
-        blob.reload()
+        tmp_path, size_bytes, checksum_sha256 = _hash_stream_to_tempfile(source)
+        try:
+            blob = self._bucket.blob(artifact_path)
+            with tmp_path.open("rb") as upload_source:
+                blob.upload_from_file(upload_source, size=size_bytes)
+        finally:
+            tmp_path.unlink(missing_ok=True)
 
         return StoredArtifact(
             path=self._to_reference_path(artifact_path),
-            size_bytes=blob.size,
-            checksum_sha256=blob.md5_hash, # We use GCS's native md5_hash instead of calculating SHA256 manually
+            size_bytes=size_bytes,
+            checksum_sha256=checksum_sha256,
         )
 
     def resolve_artifact_path(self, artifact_path: str) -> Path:
@@ -206,15 +242,18 @@ class GCSStorageService(StorageService):
             old_blob.delete()
 
         _rewind_if_possible(source)
-
-        blob = self._bucket.blob(artifact_path)
-        blob.upload_from_file(source)
-        blob.reload()
+        tmp_path, size_bytes, checksum_sha256 = _hash_stream_to_tempfile(source)
+        try:
+            blob = self._bucket.blob(artifact_path)
+            with tmp_path.open("rb") as upload_source:
+                blob.upload_from_file(upload_source, size=size_bytes)
+        finally:
+            tmp_path.unlink(missing_ok=True)
 
         return StoredArtifact(
             path=self._to_reference_path(artifact_path),
-            size_bytes=blob.size,
-            checksum_sha256=blob.md5_hash,
+            size_bytes=size_bytes,
+            checksum_sha256=checksum_sha256,
         )
 
     def has_project_preview(self, project_id: UUID) -> bool:
@@ -250,10 +289,48 @@ class GCSStorageService(StorageService):
             deleted = True
         return deleted
 
+    def store_blob(
+        self,
+        *,
+        project_id: UUID,
+        source: BinaryIO,
+    ) -> StoredArtifact:
+        _rewind_if_possible(source)
+        tmp_path, size_bytes, checksum_sha256 = _hash_stream_to_tempfile(source)
+        try:
+            blob_path = self._build_blob_path(project_id, checksum_sha256)
+            gcs_blob = self._bucket.blob(blob_path)
+            if not gcs_blob.exists():
+                with tmp_path.open("rb") as upload_source:
+                    gcs_blob.upload_from_file(upload_source, size=size_bytes)
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+        return StoredArtifact(
+            path=self._to_reference_path(blob_path),
+            size_bytes=size_bytes,
+            checksum_sha256=checksum_sha256,
+        )
+
+    def resolve_blob_path(self, storage_uri: str) -> Path:
+        return self.resolve_artifact_path(storage_uri)
+
+    def delete_blob(self, storage_uri: str) -> bool:
+        blob_path = self._to_blob_path(storage_uri)
+        gcs_blob = self._bucket.blob(blob_path)
+        if not gcs_blob.exists():
+            return False
+        gcs_blob.delete()
+        return True
+
     def _build_artifact_path(self, project_id: UUID, branch_id: UUID, version_id: UUID, filename: str) -> str:
         return (
             f"projects/{project_id}/branches/{branch_id}/versions/{version_id}/snapshot/{filename}"
         )
+
+    def _build_blob_path(self, project_id: UUID, sha256: str) -> str:
+        # Fan out by first 2 hex chars to keep any single "directory" small.
+        return f"projects/{project_id}/blobs/{sha256[:2]}/{sha256}"
 
     def _build_project_preview_prefix(self, project_id: UUID) -> str:
         return f"projects/{project_id}/preview"
@@ -365,6 +442,49 @@ class LocalFilesystemStorageService(StorageService):
             pass
 
         return deleted
+
+    def store_blob(
+        self,
+        *,
+        project_id: UUID,
+        source: BinaryIO,
+    ) -> StoredArtifact:
+        _rewind_if_possible(source)
+        tmp_path, size_bytes, checksum_sha256 = _hash_stream_to_tempfile(source)
+        try:
+            relative_path = self._blob_relative_path(project_id, checksum_sha256)
+            destination = self.root / relative_path
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            if not destination.exists():
+                tmp_path.rename(destination)
+            else:
+                tmp_path.unlink(missing_ok=True)
+        except Exception:
+            tmp_path.unlink(missing_ok=True)
+            raise
+
+        return StoredArtifact(
+            path=relative_path.as_posix(),
+            size_bytes=size_bytes,
+            checksum_sha256=checksum_sha256,
+        )
+
+    def resolve_blob_path(self, storage_uri: str) -> Path:
+        return self.resolve_artifact_path(storage_uri)
+
+    def delete_blob(self, storage_uri: str) -> bool:
+        candidate = (self.root / storage_uri).resolve()
+        try:
+            candidate.relative_to(self.root)
+        except ValueError:
+            return False
+        if not candidate.is_file():
+            return False
+        candidate.unlink()
+        return True
+
+    def _blob_relative_path(self, project_id: UUID, sha256: str) -> Path:
+        return Path("projects") / str(project_id) / "blobs" / sha256[:2] / sha256
 
 
 def _default_artifact_root() -> Path:

--- a/backend/src/stemhub/storage.py
+++ b/backend/src/stemhub/storage.py
@@ -148,6 +148,15 @@ class StorageService(ABC):
     def delete_blob(self, storage_uri: str) -> bool:
         raise NotImplementedError
 
+    def get_blob_download_url(self, storage_uri: str, *, ttl_seconds: int = 900) -> str | None:
+        """Return a URL the client can download the blob from directly.
+
+        Only meaningful for storage backends that support presigned URLs
+        (e.g. GCS). Local FS returns None; the caller should fall back to
+        streaming via FileResponse.
+        """
+        return None
+
 
 class GCSStorageService(StorageService):
     _GCS_SCHEME = "gcs://"
@@ -324,6 +333,16 @@ class GCSStorageService(StorageService):
             return False
         gcs_blob.delete()
         return True
+
+    def get_blob_download_url(self, storage_uri: str, *, ttl_seconds: int = 900) -> str | None:
+        from datetime import timedelta
+        blob_path = self._to_blob_path(storage_uri)
+        gcs_blob = self._bucket.blob(blob_path)
+        return gcs_blob.generate_signed_url(
+            expiration=timedelta(seconds=ttl_seconds),
+            method="GET",
+            version="v4",
+        )
 
     def _build_artifact_path(self, project_id: UUID, branch_id: UUID, version_id: UUID, filename: str) -> str:
         return (

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,12 @@
+"""Test bootstrap.
+
+Sets required environment variables before the stemhub package is imported.
+This is necessary because stemhub.security enforces a strong SECRET_KEY at
+module load time (see backend/src/stemhub/security.py).
+"""
+import os
+
+os.environ.setdefault(
+    "SECRET_KEY",
+    "test-secret-key-for-pytest-runs-not-for-production-use-0123456789",
+)

--- a/backend/tests/test_admin_api.py
+++ b/backend/tests/test_admin_api.py
@@ -150,3 +150,21 @@ def test_admin_stats_rejects_unauthenticated():
 
     assert response.status_code == 401
     assert response.json()["detail"] == "Could not validate credentials"
+
+
+def test_admin_blobs_gc_rejects_non_admin():
+    regular_user = _build_user(is_admin=False)
+    client = _create_test_client(current_user=regular_user)
+
+    response = client.post("/api/admin/blobs/gc")
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Admin privileges required"
+
+
+def test_admin_blobs_gc_rejects_unauthenticated():
+    client = _create_test_client()
+
+    response = client.post("/api/admin/blobs/gc")
+
+    assert response.status_code == 401

--- a/backend/tests/test_blobs_and_manifest_api.py
+++ b/backend/tests/test_blobs_and_manifest_api.py
@@ -1,0 +1,456 @@
+"""Tests for the content-addressed blob endpoints and manifest-based version create.
+
+Covers:
+- PUT /projects/{pid}/blobs/{sha256}: idempotent upload, sha256 mismatch → 400.
+- POST /branches/{bid}/versions/from-manifest: 409 on missing blobs, ref_count bump.
+- DELETE /versions/{vid}: ref_count decrement for CAS versions.
+- blob_gc.sweep_orphan_blobs: deletes ref_count==0 blobs older than grace window.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import io
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from stemhub.auth import get_current_user
+from stemhub.blob_gc import sweep_orphan_blobs
+from stemhub.database import get_db
+from stemhub.models import Blob, Branch, Project, User, Version
+from stemhub.routers.blobs import router as blobs_router
+from stemhub.routers.versions import router as versions_router
+from stemhub.storage import LocalFilesystemStorageService, get_storage_service
+
+
+# ── Fixtures ──
+
+
+def _user() -> User:
+    return User(
+        id=uuid.uuid4(),
+        email="demo@example.com",
+        username="demo",
+        password_hash="x",
+        created_at=datetime.now(timezone.utc),
+        is_active=True,
+        is_deleted=False,
+    )
+
+
+def _project(owner_id: uuid.UUID) -> Project:
+    return Project(
+        id=uuid.uuid4(),
+        owner_id=owner_id,
+        name="Demo",
+        created_at=datetime.now(timezone.utc),
+        is_deleted=False,
+        is_public=False,
+    )
+
+
+def _branch(project_id: uuid.UUID) -> Branch:
+    return Branch(
+        id=uuid.uuid4(),
+        project_id=project_id,
+        name="main",
+        created_at=datetime.now(timezone.utc),
+        is_deleted=False,
+    )
+
+
+# ── Fake session ──
+
+
+class FakeSession:
+    """In-memory stand-in for AsyncSession that knows about projects, branches,
+    versions and blobs. Only the query shapes used by the endpoints under test
+    are handled — anything else raises."""
+
+    def __init__(self, *, user: User, project: Project, branch: Branch) -> None:
+        self.user = user
+        self.project = project
+        self.branch = branch
+        self.blobs: list[Blob] = []
+        self.versions: list[Version] = []
+        self.commit_calls = 0
+
+    # ── SQLAlchemy surface ──
+
+    async def execute(self, stmt):
+        return _FakeResult(self, stmt)
+
+    def add(self, obj) -> None:
+        if isinstance(obj, Blob):
+            self.blobs.append(obj)
+        elif isinstance(obj, Version):
+            # Real SQLAlchemy would populate these from column defaults on flush.
+            if obj.id is None:
+                obj.id = uuid.uuid4()
+            if obj.created_at is None:
+                obj.created_at = datetime.now(timezone.utc)
+            if obj.is_deleted is None:
+                obj.is_deleted = False
+            self.versions.append(obj)
+        else:
+            raise TypeError(f"FakeSession does not track {type(obj).__name__}")
+
+    async def delete(self, obj) -> None:
+        if isinstance(obj, Blob):
+            self.blobs.remove(obj)
+        else:
+            raise TypeError(f"FakeSession does not delete {type(obj).__name__}")
+
+    async def commit(self) -> None:
+        self.commit_calls += 1
+
+    async def refresh(self, obj) -> None:
+        pass
+
+
+class _FakeResult:
+    def __init__(self, session: FakeSession, stmt) -> None:
+        self.session = session
+        # Interpret the statement lazily on scalars()/first()/all().
+        self.stmt = stmt
+
+    def _match(self) -> list[Any]:
+        stmt_text = str(self.stmt).lower()
+        s = self.session
+        if "from project" in stmt_text and "join" not in stmt_text:
+            return [s.project]
+        if "from branch" in stmt_text and "join project" in stmt_text:
+            return [s.branch]
+        if "from blob" in stmt_text:
+            # GC sweep matches WHERE ref_count = 0 AND created_at < cutoff.
+            # The blobs router match filters by (project_id, sha256 IN ...).
+            if "ref_count = " in stmt_text:
+                cutoff = _extract_cutoff(self.stmt)
+                candidates = [b for b in s.blobs if b.ref_count == 0]
+                if cutoff is not None:
+                    candidates = [b for b in candidates if b.created_at < cutoff]
+                return candidates
+            wanted = _extract_sha_set(self.stmt)
+            if wanted is not None:
+                return [b for b in s.blobs if b.sha256 in wanted]
+            return list(s.blobs)
+        if "from version" in stmt_text:
+            wanted_id = _extract_version_id(self.stmt)
+            if wanted_id is not None:
+                # Return (Version, project_id) row tuple as delete_version expects.
+                for v in s.versions:
+                    if v.id == wanted_id and not v.is_deleted:
+                        return [(v, s.project.id)]
+                return []
+            return [v for v in s.versions if not v.is_deleted]
+        if "from users" in stmt_text or "from user" in stmt_text:
+            return [s.user]
+        raise NotImplementedError(f"FakeSession does not know how to answer: {stmt_text[:200]}")
+
+    def scalars(self):
+        rows = self._match()
+        # If _match returned tuples (delete_version case), keep them as-is.
+        return _FakeScalars(rows)
+
+    def scalar_one_or_none(self):
+        rows = self._match()
+        return rows[0] if rows else None
+
+    def first(self):
+        rows = self._match()
+        return rows[0] if rows else None
+
+    def all(self):
+        rows = self._match()
+        # For blob-sha listing, return list of (sha,) tuples.
+        return [(r.sha256,) if isinstance(r, Blob) else r for r in rows]
+
+
+class _FakeScalars:
+    def __init__(self, rows: list[Any]) -> None:
+        self._rows = rows
+
+    def first(self):
+        return self._rows[0] if self._rows else None
+
+    def all(self):
+        return self._rows
+
+
+def _extract_sha_set(stmt) -> set[str] | None:
+    """Best-effort extraction of the IN (...) sha256 set from a SQLAlchemy stmt."""
+    try:
+        for clause in stmt.whereclause.get_children():
+            # Look for an IN clause on Blob.sha256
+            if hasattr(clause, "right") and hasattr(clause.right, "value"):
+                value = clause.right.value
+                if isinstance(value, (list, tuple, set)):
+                    if all(isinstance(v, str) and len(v) == 64 for v in value):
+                        return set(value)
+    except AttributeError:
+        pass
+    return None
+
+
+def _extract_cutoff(stmt) -> datetime | None:
+    try:
+        for clause in stmt.whereclause.get_children():
+            if hasattr(clause, "right") and hasattr(clause.right, "value"):
+                value = clause.right.value
+                if isinstance(value, datetime):
+                    return value
+    except AttributeError:
+        pass
+    return None
+
+
+def _extract_version_id(stmt) -> uuid.UUID | None:
+    try:
+        for clause in stmt.whereclause.get_children():
+            if hasattr(clause, "right") and hasattr(clause.right, "value"):
+                value = clause.right.value
+                if isinstance(value, uuid.UUID):
+                    return value
+    except AttributeError:
+        pass
+    return None
+
+
+# ── Test client factory ──
+
+
+def _make_client(session: FakeSession, storage_service) -> TestClient:
+    app = FastAPI()
+    app.include_router(blobs_router)
+    app.include_router(versions_router)
+
+    async def override_db():
+        yield session
+
+    async def override_user():
+        return session.user
+
+    app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_current_user] = override_user
+    app.dependency_overrides[get_storage_service] = lambda: storage_service
+    return TestClient(app)
+
+
+# ── Blob upload tests ──
+
+
+def test_blob_upload_stores_bytes_and_row(tmp_path) -> None:
+    user = _user()
+    project = _project(user.id)
+    branch = _branch(project.id)
+    session = FakeSession(user=user, project=project, branch=branch)
+    storage = LocalFilesystemStorageService(tmp_path)
+    client = _make_client(session, storage)
+
+    payload = b"hello world"
+    sha = hashlib.sha256(payload).hexdigest()
+
+    response = client.put(
+        f"/projects/{project.id}/blobs/{sha}",
+        files={"file": ("kick.wav", io.BytesIO(payload), "audio/wav")},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["sha256"] == sha
+    assert body["size_bytes"] == len(payload)
+    assert len(session.blobs) == 1
+    assert session.blobs[0].ref_count == 0
+
+
+def test_blob_upload_rejects_sha_mismatch(tmp_path) -> None:
+    user = _user()
+    project = _project(user.id)
+    branch = _branch(project.id)
+    session = FakeSession(user=user, project=project, branch=branch)
+    storage = LocalFilesystemStorageService(tmp_path)
+    client = _make_client(session, storage)
+
+    # Claim a hash that doesn't match the bytes.
+    lying_sha = "0" * 64
+    response = client.put(
+        f"/projects/{project.id}/blobs/{lying_sha}",
+        files={"file": ("kick.wav", io.BytesIO(b"different bytes"), "audio/wav")},
+    )
+    assert response.status_code == 400
+    assert "mismatch" in response.json()["detail"]
+    assert session.blobs == []
+
+
+# ── from-manifest tests ──
+
+
+def _manifest(project_sha: str, project_size: int, track_sha: str, track_size: int) -> dict:
+    return {
+        "manifest_version": 1,
+        "source_daw": "FL Studio",
+        "source_project_filename": "song.flp",
+        "project_file": {
+            "sha256": project_sha,
+            "size_bytes": project_size,
+            "filename": "song.flp",
+        },
+        "tracks": [
+            {
+                "sha256": track_sha,
+                "size_bytes": track_size,
+                "filename": "kick.wav",
+                "name": "Kick",
+            },
+        ],
+    }
+
+
+def test_create_version_from_manifest_bumps_ref_count(tmp_path) -> None:
+    user = _user()
+    project = _project(user.id)
+    branch = _branch(project.id)
+    session = FakeSession(user=user, project=project, branch=branch)
+
+    proj_bytes = b"flp bytes"
+    track_bytes = b"wav bytes"
+    proj_sha = hashlib.sha256(proj_bytes).hexdigest()
+    track_sha = hashlib.sha256(track_bytes).hexdigest()
+
+    session.blobs.append(Blob(
+        project_id=project.id, sha256=proj_sha, size_bytes=len(proj_bytes),
+        storage_uri="x", ref_count=0,
+        created_at=datetime.now(timezone.utc),
+    ))
+    session.blobs.append(Blob(
+        project_id=project.id, sha256=track_sha, size_bytes=len(track_bytes),
+        storage_uri="y", ref_count=0,
+        created_at=datetime.now(timezone.utc),
+    ))
+
+    client = _make_client(session, LocalFilesystemStorageService(tmp_path))
+    response = client.post(
+        f"/branches/{branch.id}/versions/from-manifest",
+        json={
+            "commit_message": "first cut",
+            "manifest": _manifest(proj_sha, len(proj_bytes), track_sha, len(track_bytes)),
+        },
+    )
+    assert response.status_code == 201, response.text
+    body = response.json()
+    assert body["source_daw"] == "FL Studio"
+    assert body["manifest_version"] == 1
+    # ref_count bumped exactly once per referenced blob
+    assert all(b.ref_count == 1 for b in session.blobs)
+    assert len(session.versions) == 1
+
+
+def test_create_version_from_manifest_returns_409_when_blobs_missing(tmp_path) -> None:
+    user = _user()
+    project = _project(user.id)
+    branch = _branch(project.id)
+    session = FakeSession(user=user, project=project, branch=branch)
+
+    proj_sha = "a" * 64
+    track_sha = "b" * 64
+
+    client = _make_client(session, LocalFilesystemStorageService(tmp_path))
+    response = client.post(
+        f"/branches/{branch.id}/versions/from-manifest",
+        json={
+            "manifest": _manifest(proj_sha, 10, track_sha, 20),
+        },
+    )
+    assert response.status_code == 409
+    detail = response.json()["detail"]
+    assert detail["error"] == "missing_blobs"
+    assert set(detail["missing"]) == {proj_sha, track_sha}
+    assert session.versions == []
+
+
+# ── delete_version ref_count decrement ──
+
+
+def test_delete_cas_version_decrements_ref_count(tmp_path) -> None:
+    user = _user()
+    project = _project(user.id)
+    branch = _branch(project.id)
+    session = FakeSession(user=user, project=project, branch=branch)
+
+    proj_sha = "c" * 64
+    track_sha = "d" * 64
+    session.blobs.append(Blob(
+        project_id=project.id, sha256=proj_sha, size_bytes=1,
+        storage_uri="x", ref_count=1,
+        created_at=datetime.now(timezone.utc),
+    ))
+    session.blobs.append(Blob(
+        project_id=project.id, sha256=track_sha, size_bytes=1,
+        storage_uri="y", ref_count=2,  # referenced by another version too
+        created_at=datetime.now(timezone.utc),
+    ))
+    version = Version(
+        id=uuid.uuid4(),
+        branch_id=branch.id,
+        created_at=datetime.now(timezone.utc),
+        is_deleted=False,
+        manifest_json=_manifest(proj_sha, 1, track_sha, 1),
+        manifest_version=1,
+    )
+    session.versions.append(version)
+
+    client = _make_client(session, LocalFilesystemStorageService(tmp_path))
+    response = client.delete(f"/versions/{version.id}")
+    assert response.status_code == 204
+    assert version.is_deleted is True
+    assert next(b for b in session.blobs if b.sha256 == proj_sha).ref_count == 0
+    assert next(b for b in session.blobs if b.sha256 == track_sha).ref_count == 1
+
+
+# ── GC sweep ──
+
+
+def test_gc_sweep_deletes_old_orphan_blobs(tmp_path) -> None:
+    asyncio.run(_gc_sweep_body(tmp_path))
+
+
+async def _gc_sweep_body(tmp_path) -> None:
+    user = _user()
+    project = _project(user.id)
+    branch = _branch(project.id)
+    session = FakeSession(user=user, project=project, branch=branch)
+    storage = LocalFilesystemStorageService(tmp_path)
+
+    # Two blobs: one orphan+old (should be deleted), one orphan+recent (kept),
+    # one referenced+old (kept).
+    now = datetime.now(timezone.utc)
+    stored_old = storage.store_blob(project_id=project.id, source=io.BytesIO(b"old"))
+    stored_recent = storage.store_blob(project_id=project.id, source=io.BytesIO(b"recent"))
+    stored_ref = storage.store_blob(project_id=project.id, source=io.BytesIO(b"ref"))
+
+    session.blobs.append(Blob(
+        project_id=project.id, sha256=stored_old.checksum_sha256, size_bytes=stored_old.size_bytes,
+        storage_uri=stored_old.path, ref_count=0,
+        created_at=now - timedelta(hours=48),
+    ))
+    session.blobs.append(Blob(
+        project_id=project.id, sha256=stored_recent.checksum_sha256, size_bytes=stored_recent.size_bytes,
+        storage_uri=stored_recent.path, ref_count=0,
+        created_at=now,
+    ))
+    session.blobs.append(Blob(
+        project_id=project.id, sha256=stored_ref.checksum_sha256, size_bytes=stored_ref.size_bytes,
+        storage_uri=stored_ref.path, ref_count=3,
+        created_at=now - timedelta(hours=48),
+    ))
+
+    result = await sweep_orphan_blobs(db=session, storage=storage, grace_hours=24)
+    assert result.deleted == 1
+    assert result.failed == 0
+    remaining_shas = {b.sha256 for b in session.blobs}
+    assert stored_old.checksum_sha256 not in remaining_shas
+    assert stored_recent.checksum_sha256 in remaining_shas
+    assert stored_ref.checksum_sha256 in remaining_shas

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -99,7 +99,8 @@ def test_gcs_storage_service_roundtrip(monkeypatch) -> None:
             with open(source_path, "rb") as file:
                 uploaded_blobs[self.path] = file.read()
 
-        def upload_from_file(self, source_file) -> None:
+        def upload_from_file(self, source_file, size=None) -> None:
+            del size
             uploaded_blobs[self.path] = source_file.read()
 
         def reload(self) -> None:

--- a/docs/content-addressed-storage.md
+++ b/docs/content-addressed-storage.md
@@ -1,0 +1,153 @@
+# Content-Addressed Storage — Design
+
+## Problem
+
+The current storage model treats every version as a single opaque bundle: each commit re-uploads and re-stores the entire DAW project (FLP + all audio stems). For a typical mixing workflow — where a session might contain 200–500 MB of unchanged audio and 1–2 MB of edited FLP — this wastes:
+
+- **Storage:** N copies of the same 500 MB stem set for a project with N versions.
+- **Bandwidth:** The plugin re-uploads the same stems on every commit; slow, and painful on residential upload speeds.
+- **Time:** Push/pull latency scales with total session size, not with what actually changed.
+
+## Goal
+
+Store each unique audio file **once per project** and represent each version as a lightweight JSON manifest that references those shared blobs by SHA-256. This is exactly how Git's object model works (blobs + tree + commit).
+
+## Model
+
+### `blob` table
+
+Content-addressed rows, one per unique file per project (see "Scope" below).
+
+| column          | type          | notes                                          |
+|-----------------|---------------|------------------------------------------------|
+| `sha256`        | `CHAR(64)` PK | Hex-encoded SHA-256 of the raw bytes.          |
+| `project_id`    | `UUID` FK     | Blobs are project-scoped (privacy — see below).|
+| `size_bytes`    | `BIGINT`      | Uncompressed size.                             |
+| `mime_type`     | `VARCHAR(80)` | Best-effort; not authoritative.                |
+| `storage_uri`   | `TEXT`        | Backend-specific location (localfs or GCS).    |
+| `created_at`    | `TIMESTAMPTZ` | First time this blob was uploaded.             |
+| `ref_count`     | `INT`         | Number of live manifests referencing it. GC uses this. |
+
+**Composite PK:** `(project_id, sha256)`. A file with the same bytes uploaded to two different projects is stored twice — see "Scope: project-scoped vs global."
+
+### `version` table (changes)
+
+Existing columns stay for backward compatibility during rollout. Add:
+
+| column           | type   | notes                                       |
+|------------------|--------|---------------------------------------------|
+| `manifest_json`  | `JSONB`| The full manifest (see below).              |
+| `manifest_version` | `INT` | Schema version of `manifest_json`. Start at 1. |
+
+Deprecate (but don't drop yet): `artifact_path`, `artifact_size_bytes`, `artifact_checksum`. These are replaced by references inside `manifest_json`.
+
+### Manifest schema (v1)
+
+```json
+{
+  "manifest_version": 1,
+  "source_daw": "FL Studio",
+  "source_project_filename": "MyTrack.flp",
+  "project_file": {
+    "sha256": "abc...",
+    "size_bytes": 1843200,
+    "filename": "MyTrack.flp"
+  },
+  "tracks": [
+    {
+      "name": "Kick",
+      "sha256": "def...",
+      "size_bytes": 4823040,
+      "filename": "kick.wav",
+      "bpm": 128,
+      "key": "F#m",
+      "duration_seconds": 12
+    }
+  ],
+  "mixer_state": { ... existing snapshot_manifest ... }
+}
+```
+
+Rules:
+- `manifest_version` is required from day one. Bump when schema changes.
+- All referenced blobs must exist in the `blob` table for this project before the manifest can be saved.
+- Filenames inside the manifest are display-only. Actual retrieval is by SHA-256.
+
+## Scope: project-scoped vs global blobs
+
+**Decision: project-scoped.**
+
+Global dedupe would maximize storage savings (samples reused across projects would coalesce), but it opens a **privacy oracle**: a user could upload a suspected file and check whether the server "already has it" — leaking the fact that another user has that content. This is a known attack against consumer deduplicated cloud storage (Dropbox had CVE-style disclosures around this).
+
+Project-scoped dedupe still solves 95% of the problem (the wasteful case is *the same project* being pushed repeatedly), with no privacy leak.
+
+## Upload flow (plugin ↔ backend)
+
+Client-side hashing is mandatory — the whole point is that the client can skip uploading blobs the server already has.
+
+```
+1. Plugin snapshots the DAW session → list of files (FLP + stems).
+2. For each file, plugin computes SHA-256 locally.
+3. Plugin POSTs POST /projects/{pid}/blobs/check
+     body: {"sha256s": ["abc...", "def...", ...]}
+   → returns {"missing": ["def..."]}   (only blobs the server needs)
+4. For each missing sha256:
+     Server returns a presigned PUT URL (GCS) or a token-scoped upload endpoint (localfs).
+     Plugin uploads bytes directly to that URL.
+     Server verifies SHA-256 after upload (integrity guarantee). On mismatch → delete blob, 400.
+5. Plugin POSTs POST /projects/{pid}/branches/{bid}/versions
+     body: { "commit_message": "...", "manifest": { ...manifest v1... } }
+     Server validates:
+       - manifest_version supported
+       - every referenced sha256 exists in blob table for this project
+       - increments ref_count for each referenced blob
+     Server writes the Version row atomically.
+```
+
+**Atomicity:** Uploads are idempotent by SHA-256 (uploading twice produces the same row). Version creation is a single DB transaction. If step 5 fails, the uploaded blobs stay — they'll be reclaimed by GC because `ref_count == 0`.
+
+## Download flow (pull)
+
+```
+1. Plugin GETs GET /versions/{vid}     → returns manifest_json.
+2. Plugin diffs local filesystem against manifest → list of missing sha256s.
+3. For each missing sha256, plugin GETs GET /projects/{pid}/blobs/{sha256}
+   → server returns a presigned GET URL (GCS) or 302 to a signed local endpoint.
+4. Plugin downloads, verifies SHA-256 locally before writing to disk.
+```
+
+## Garbage collection
+
+Two options; recommend **eager ref_count with periodic sweep as safety net**:
+
+1. **Eager ref_count:** Increment on version create, decrement on soft-delete. Cheap, correct if all writes go through the version-create endpoint.
+2. **Periodic sweep:** A daily job (start weekly) scans blobs where `ref_count == 0 AND created_at < now() - 24h` and deletes them. The 24h grace window prevents races where a client uploaded blobs but hasn't POSTed the version yet.
+
+## Presigned URLs
+
+**GCS:** use `blob.generate_signed_url(expiration=15min, method="PUT"/"GET")`. Cheap, offloads all bytes from the API server, works with the existing GCS service-account credentials.
+
+**LocalFS (dev only):** implement a token-scoped `/internal/blob-upload/{token}` endpoint. Token is a signed JWT containing `{sha256, project_id, exp}`. Same API shape as GCS presigned URLs, so client code is uniform.
+
+## Migration path (from current schema)
+
+The user is at < 100 users. Simplest path:
+
+1. Ship the new schema behind an unused endpoint set (`/v2/...` or feature-flagged).
+2. Backfill: for each existing Version, treat the whole artifact bundle as a single blob (SHA-256 the archive, insert one `blob` row, build a minimal manifest with `manifest_version: 0` meaning "legacy bundle"). This is a one-shot script.
+3. Switch the plugin to the new endpoints. Old versions remain readable via the legacy code path.
+4. After 30 days with no legacy pulls, delete the legacy fields.
+
+If wiping alpha data is acceptable, skip steps 2–4 and cut over directly.
+
+## Non-goals for v1
+
+- Cross-project dedupe (privacy).
+- Delta compression within a blob (git's pack files). Blob-level dedupe already solves the common case.
+- Client-side diff of FLP internals (would require a DAW-format-aware differ; huge scope).
+
+## Open questions
+
+- **Blob size ceiling.** Multi-gigabyte stems will need multipart/resumable upload (GCS supports it). Defer until we see it in practice.
+- **Encryption at rest.** GCS default is fine for alpha; if we later need customer-managed keys, the blob abstraction contains the change.
+- **Public projects & blob visibility.** When a project is `is_public=True`, blobs referenced by public versions must be readable by anonymous clients. Solution: presigned GET URLs from an authenticated endpoint that checks the project's visibility.

--- a/plugin/stemhub/CMakeLists.txt
+++ b/plugin/stemhub/CMakeLists.txt
@@ -73,6 +73,7 @@ target_compile_definitions(stemhub
 target_link_libraries(stemhub
     PRIVATE
         juce::juce_audio_utils
+        juce::juce_cryptography
         juce::juce_recommended_config_flags
         juce::juce_recommended_lto_flags
         juce::juce_recommended_warning_flags)
@@ -119,6 +120,7 @@ target_link_libraries(stemhub_plugin_tests
     PRIVATE
         CURL::libcurl
         juce::juce_audio_utils
+        juce::juce_cryptography
         juce::juce_recommended_config_flags
         juce::juce_recommended_lto_flags
         juce::juce_recommended_warning_flags)

--- a/plugin/stemhub/Source/include/application/PluginProcessor.hpp
+++ b/plugin/stemhub/Source/include/application/PluginProcessor.hpp
@@ -100,6 +100,10 @@ public:
     // whole-project bundle. See docs/content-addressed-storage.md.
     void requestPushVersionContentAddressed(juce::String commitMessage, juce::String dawName);
     void requestRestoreVersion(const juce::String& versionId, const juce::File& destinationFolder);
+    // Content-addressed restore: fetches the version's manifest and downloads
+    // only the referenced blobs into destinationFolder, verifying SHA-256.
+    // See docs/content-addressed-storage.md.
+    void requestRestoreVersionContentAddressed(const juce::String& versionId, const juce::File& destinationFolder);
 
     void setSelectedVersionId(juce::String versionId);
     VersionControlService& getVersionControlService() noexcept { return versionControlService; }
@@ -173,6 +177,7 @@ private:
     void enqueueBackgroundTask(std::function<BackgroundJobPayload()> job);
 
     RestoreVersionJobResult performRestoreVersionRequest(const juce::String& versionId, const juce::File& destinationFile) const;
+    RestoreVersionJobResult performRestoreVersionContentAddressedRequest(const juce::String& versionId, const juce::File& destinationFolder);
     AuthRequestResult performSignInRequest(const juce::String& email, const juce::String& password) const;
     AuthRequestResult performRestoreCachedSessionRequest(const juce::String& token) const;
     ProjectActivationJobResult performOpenProjectRequest(const juce::String& projectId,

--- a/plugin/stemhub/Source/include/application/PluginProcessor.hpp
+++ b/plugin/stemhub/Source/include/application/PluginProcessor.hpp
@@ -96,6 +96,9 @@ public:
     void requestSelectBranch(juce::String branchId);
     void requestRefreshVersionHistory();
     void requestPushVersion(juce::String commitMessage, juce::String dawName);
+    // Content-addressed variant: uploads only novel blobs instead of the full
+    // whole-project bundle. See docs/content-addressed-storage.md.
+    void requestPushVersionContentAddressed(juce::String commitMessage, juce::String dawName);
     void requestRestoreVersion(const juce::String& versionId, const juce::File& destinationFolder);
 
     void setSelectedVersionId(juce::String versionId);
@@ -189,6 +192,12 @@ private:
                                                    const juce::String& branchId,
                                                    const juce::String& commitMessage,
                                                    const juce::String& dawName);
+    PushVersionJobResult performPushVersionContentAddressedRequest(const juce::File& projectFile,
+                                                                    const juce::File& projectRootDirectory,
+                                                                    const std::optional<Project>& project,
+                                                                    const juce::String& branchId,
+                                                                    const juce::String& commitMessage,
+                                                                    const juce::String& dawName);
     void applyBackgroundResult(BackgroundJobResult result);
     void applyAuthRequestResult(AuthRequestResult result);
     void applyProjectActivationResult(ProjectActivationJobResult result);

--- a/plugin/stemhub/Source/include/application/SnapshotBundler.hpp
+++ b/plugin/stemhub/Source/include/application/SnapshotBundler.hpp
@@ -31,6 +31,24 @@ struct ContentAddressedManifest
     std::vector<ContentAddressedFileEntry> entries;
 };
 
+// Parsed entry from a v1 manifest — describes ONE blob the client needs to
+// materialize during pull, plus where to put it.
+struct ParsedManifestEntry
+{
+    juce::String sha256;
+    juce::int64 sizeBytes { 0 };
+    juce::String filename;    // basename; used relative to the restore directory
+    bool isProjectFile { false };
+};
+
+struct ParsedManifest
+{
+    int manifestVersion { 0 };
+    juce::String sourceDaw;
+    juce::String sourceProjectFilename;
+    std::vector<ParsedManifestEntry> entries;   // project file first if present
+};
+
 class SnapshotBundler
 {
     public:
@@ -43,4 +61,10 @@ class SnapshotBundler
         // Does NOT write a zip.
         [[nodiscard]] juce::Result buildContentAddressedManifest(const SnapshotBundleRequest& request,
                                                                     ContentAddressedManifest& outResult) const;
+
+        // Parse a v1 manifest_json blob (as returned by GET /versions/{vid})
+        // into a flat list of entries the caller can iterate to download blobs.
+        // Only accepts manifest_version == 1.
+        [[nodiscard]] static juce::Result parseContentAddressedManifest(const juce::var& manifestJson,
+                                                                         ParsedManifest& outResult);
 };

--- a/plugin/stemhub/Source/include/application/SnapshotBundler.hpp
+++ b/plugin/stemhub/Source/include/application/SnapshotBundler.hpp
@@ -16,9 +16,31 @@ struct SnapshotBundleResult
     juce::var manifest;
 };
 
+struct ContentAddressedFileEntry
+{
+    juce::File file;          // absolute local path
+    juce::String sha256;      // lowercase hex, 64 chars
+    juce::int64 sizeBytes { 0 };
+    juce::String filename;    // basename (for display)
+    bool isProjectFile { false };
+};
+
+struct ContentAddressedManifest
+{
+    juce::var manifestJson;   // matches VersionManifestV1 shape on the backend
+    std::vector<ContentAddressedFileEntry> entries;
+};
+
 class SnapshotBundler
 {
     public:
         [[nodiscard]] juce::Result bundleProject(const SnapshotBundleRequest& request,
                                                     SnapshotBundleResult& outResult) const;
+
+        // Content-addressed variant: hash every included file (project + assets),
+        // build a VersionManifestV1-shaped juce::var, and return both the manifest
+        // and the entries so the caller can call check-missing + uploadBlob.
+        // Does NOT write a zip.
+        [[nodiscard]] juce::Result buildContentAddressedManifest(const SnapshotBundleRequest& request,
+                                                                    ContentAddressedManifest& outResult) const;
 };

--- a/plugin/stemhub/Source/include/application/VersionControlService.hpp
+++ b/plugin/stemhub/Source/include/application/VersionControlService.hpp
@@ -32,7 +32,15 @@ class VersionControlService
         // create version from manifest. See docs/content-addressed-storage.md.
         // Only re-uploads blobs the server doesn't already have.
         juce::Result pushVersionContentAddressed(const PushVersionCasRequest& request);
-    
+
+        // Content-addressed pull: fetch the version's manifest, download each
+        // referenced blob into restoreDirectory (verifying SHA-256 per file),
+        // and return the path of the project file entry via outProjectFile.
+        juce::Result restoreVersionFromManifest(const juce::String& projectId,
+                                                const juce::String& versionId,
+                                                const juce::File& restoreDirectory,
+                                                juce::File& outProjectFile);
+
         ApiResult<std::vector<VersionSummary>> fetchVersionHistory(
             const juce::String& branchId,
             const juce::String& accessToken) const;

--- a/plugin/stemhub/Source/include/application/VersionControlService.hpp
+++ b/plugin/stemhub/Source/include/application/VersionControlService.hpp
@@ -2,7 +2,17 @@
 
 #include <JuceHeader.h>
 #include "network/ApiClient.hpp"
+#include "application/SnapshotBundler.hpp"
 #include "application/VersionControlUtils.hpp"
+
+struct PushVersionCasRequest
+{
+    juce::String projectId;
+    juce::String branchId;
+    juce::String commitMessage;
+    juce::String parentVersionId;
+    ContentAddressedManifest manifest;
+};
 
 class VersionControlService
 {
@@ -17,6 +27,11 @@ class VersionControlService
         }
     
         juce::Result pushVersion(const PushVersionRequest& request);
+
+        // Content-addressed push: hash → check-missing → upload novel blobs →
+        // create version from manifest. See docs/content-addressed-storage.md.
+        // Only re-uploads blobs the server doesn't already have.
+        juce::Result pushVersionContentAddressed(const PushVersionCasRequest& request);
     
         ApiResult<std::vector<VersionSummary>> fetchVersionHistory(
             const juce::String& branchId,

--- a/plugin/stemhub/Source/include/network/ApiClient.hpp
+++ b/plugin/stemhub/Source/include/network/ApiClient.hpp
@@ -45,6 +45,13 @@ public:
     virtual ApiResult<juce::var> createVersionFromManifest(const juce::String& branchId,
                                                             const juce::var& payload,
                                                             const juce::String& accessToken) const = 0;
+    // Download a single blob to a local file. Backend may 307-redirect to a
+    // presigned URL (GCS) — juce::URL's input stream follows redirects by
+    // default so the implementation is a normal GET.
+    virtual juce::Result downloadBlob(const juce::String& projectId,
+                                       const juce::String& sha256,
+                                       const juce::File& destinationFile,
+                                       const juce::String& accessToken) const = 0;
 };
 
 class ApiClient final : public IProjectApi
@@ -80,6 +87,10 @@ public:
     ApiResult<juce::var> createVersionFromManifest(const juce::String& branchId,
                                                     const juce::var& payload,
                                                     const juce::String& accessToken) const override;
+    juce::Result downloadBlob(const juce::String& projectId,
+                               const juce::String& sha256,
+                               const juce::File& destinationFile,
+                               const juce::String& accessToken) const override;
 
 private:
     juce::String baseUrl;

--- a/plugin/stemhub/Source/include/network/ApiClient.hpp
+++ b/plugin/stemhub/Source/include/network/ApiClient.hpp
@@ -28,6 +28,23 @@ public:
     virtual ApiResult<std::vector<Project>> fetchProjects(const juce::String& accessToken) const = 0;
     virtual ApiResult<Project> createProject(const juce::String& name, const juce::String& accessToken) const = 0;
     virtual ApiResult<std::vector<Branch>> fetchBranches(const juce::String& projectId, const juce::String& accessToken) const = 0;
+
+    // ── Content-addressed storage (see docs/content-addressed-storage.md) ──
+    // Batched "which of these blobs do you already have?" query. Returns the
+    // subset the server does NOT have, so the client only uploads those.
+    virtual ApiResult<std::vector<juce::String>> checkMissingBlobs(const juce::String& projectId,
+                                                                    const std::vector<juce::String>& sha256s,
+                                                                    const juce::String& accessToken) const = 0;
+    // Idempotent PUT of a single blob. sha256 in URL is verified against the
+    // received bytes server-side; mismatch → 400 and no row.
+    virtual ApiResult<juce::var> uploadBlob(const juce::String& projectId,
+                                             const juce::String& sha256,
+                                             const juce::File& file,
+                                             const juce::String& accessToken) const = 0;
+    // Create a Version by referencing already-uploaded blobs.
+    virtual ApiResult<juce::var> createVersionFromManifest(const juce::String& branchId,
+                                                            const juce::var& payload,
+                                                            const juce::String& accessToken) const = 0;
 };
 
 class ApiClient final : public IProjectApi
@@ -52,6 +69,17 @@ public:
     ApiResult<std::vector<Project>> fetchProjects(const juce::String& accessToken) const override;
     ApiResult<Project> createProject(const juce::String& name, const juce::String& accessToken) const override;
     ApiResult<std::vector<Branch>> fetchBranches(const juce::String& projectId, const juce::String& accessToken) const override;
+
+    ApiResult<std::vector<juce::String>> checkMissingBlobs(const juce::String& projectId,
+                                                            const std::vector<juce::String>& sha256s,
+                                                            const juce::String& accessToken) const override;
+    ApiResult<juce::var> uploadBlob(const juce::String& projectId,
+                                     const juce::String& sha256,
+                                     const juce::File& file,
+                                     const juce::String& accessToken) const override;
+    ApiResult<juce::var> createVersionFromManifest(const juce::String& branchId,
+                                                    const juce::var& payload,
+                                                    const juce::String& accessToken) const override;
 
 private:
     juce::String baseUrl;

--- a/plugin/stemhub/Source/src/application/ProcProject.cpp
+++ b/plugin/stemhub/Source/src/application/ProcProject.cpp
@@ -626,6 +626,48 @@ void StemhubAudioProcessor::requestRestoreVersion(const juce::String& versionId,
     });
 }
 
+void StemhubAudioProcessor::requestRestoreVersionContentAddressed(const juce::String& versionId, const juce::File& projectFolder)
+{
+    if (!hasProjectAndBranchSelected(selectedProject, selectedBranchId))
+    {
+        setOperationState(OperationState::error);
+        setActiveProjectStatusMessage("Choose a project before restoring.");
+        return;
+    }
+    if (!projectFolder.isDirectory())
+    {
+        setOperationState(OperationState::error);
+        setActiveProjectStatusMessage("Choose a valid restore destination folder.");
+        return;
+    }
+    if (versionId.isEmpty())
+    {
+        setOperationState(OperationState::error);
+        setActiveProjectStatusMessage("Select a version before restoring.");
+        return;
+    }
+
+    const auto projectName = selectedProject ? selectedProject->name : juce::String();
+    const auto restoredProjectBase = stemhub::projectfiles::resolveRestoreProjectName(versionHistory, versionId, projectName);
+    // Materialize the blobs into a per-version subdirectory to avoid clobbering
+    // adjacent restores. Matches the shape of the legacy restore path.
+    const auto restoreDir = projectFolder.getChildFile(
+        restoredProjectBase + "-" + versionId.substring(0, juce::jmin(8, versionId.length())));
+
+    setOperationState(OperationState::pulling);
+    setActiveProjectStatusMessage("Restoring selected version...");
+    sendChangeMessage();
+
+    const auto requestedVersionId = versionId;
+    const auto requestedRestoreDir = restoreDir;
+    enqueueBackgroundTask([this,
+                           requestedVersionId,
+                           requestedRestoreDir]() mutable -> BackgroundJobPayload
+    {
+        return performRestoreVersionContentAddressedRequest(requestedVersionId, requestedRestoreDir);
+    });
+}
+
 void StemhubAudioProcessor::setSelectedVersionId(juce::String versionId)
 {
     selectedVersionId = std::move(versionId);

--- a/plugin/stemhub/Source/src/application/ProcProject.cpp
+++ b/plugin/stemhub/Source/src/application/ProcProject.cpp
@@ -552,6 +552,32 @@ void StemhubAudioProcessor::requestPushVersion(juce::String commitMessage, juce:
     });
 }
 
+void StemhubAudioProcessor::requestPushVersionContentAddressed(juce::String commitMessage, juce::String dawName)
+{
+    setOperationState(OperationState::committing);
+    sendChangeMessage();
+
+    const auto projectFile = stemhub::projectfiles::resolveEffectiveProjectFile(selectedProjectFile, pendingProjectFile);
+    const auto projectRootDirectory = projectFile.existsAsFile() ? projectFile.getParentDirectory() : juce::File();
+    const auto project = selectedProject;
+    const auto branchId = selectedBranchId;
+    enqueueBackgroundTask([this,
+                           selectedFile = std::move(projectFile),
+                           selectedProjectRoot = std::move(projectRootDirectory),
+                           project,
+                           selectedBranch = std::move(branchId),
+                           requestedCommitMessage = std::move(commitMessage),
+                           requestedDawName = std::move(dawName)]() mutable -> BackgroundJobPayload
+    {
+        return performPushVersionContentAddressedRequest(selectedFile,
+                                                          selectedProjectRoot,
+                                                          project,
+                                                          selectedBranch,
+                                                          requestedCommitMessage,
+                                                          requestedDawName);
+    });
+}
+
 void StemhubAudioProcessor::requestRestoreVersion(const juce::String& versionId, const juce::File& projectFolder)
 {
     juce::Logger::writeToLog("[Restore] Processor -> requestRestoreVersion called. versionId=" + versionId

--- a/plugin/stemhub/Source/src/application/ProcVerJobs.cpp
+++ b/plugin/stemhub/Source/src/application/ProcVerJobs.cpp
@@ -221,6 +221,52 @@ StemhubAudioProcessor::PushVersionJobResult StemhubAudioProcessor::performPushVe
     return result;
 }
 
+StemhubAudioProcessor::RestoreVersionJobResult StemhubAudioProcessor::performRestoreVersionContentAddressedRequest(
+    const juce::String& versionId, const juce::File& destinationFolder)
+{
+    RestoreVersionJobResult result;
+    result.restoredVersionId = versionId;
+
+    if (versionId.isEmpty())
+    {
+        result.errorMessage = "Select a version before restoring.";
+        return result;
+    }
+    if (destinationFolder.exists() && !destinationFolder.isDirectory())
+    {
+        result.errorMessage = "Restore destination is not a directory: " + destinationFolder.getFullPathName();
+        return result;
+    }
+    if (!selectedProject)
+    {
+        result.errorMessage = "Choose a project before restoring.";
+        return result;
+    }
+
+    // Clear any previous restore contents at that path so download starts fresh.
+    if (destinationFolder.exists())
+    {
+        if (!destinationFolder.deleteRecursively())
+        {
+            result.errorMessage = "Failed to clear previous restore folder at " + destinationFolder.getFullPathName();
+            return result;
+        }
+    }
+
+    juce::File restoredProjectFile;
+    const auto status = versionControlService.restoreVersionFromManifest(
+        selectedProject->id, versionId, destinationFolder, restoredProjectFile);
+    if (status.failed())
+    {
+        result.errorMessage = status.getErrorMessage();
+        return result;
+    }
+
+    result.restoredProjectFile = restoredProjectFile;
+    result.activeProjectStatusMessage = "Version restored successfully: " + restoredProjectFile.getFileName();
+    return result;
+}
+
 StemhubAudioProcessor::RestoreVersionJobResult StemhubAudioProcessor::performRestoreVersionRequest(
     const juce::String& versionId,
     const juce::File& destinationFile) const

--- a/plugin/stemhub/Source/src/application/ProcVerJobs.cpp
+++ b/plugin/stemhub/Source/src/application/ProcVerJobs.cpp
@@ -150,6 +150,77 @@ StemhubAudioProcessor::PushVersionJobResult StemhubAudioProcessor::performPushVe
     return result;
 }
 
+StemhubAudioProcessor::PushVersionJobResult StemhubAudioProcessor::performPushVersionContentAddressedRequest(
+    const juce::File& projectFile,
+    const juce::File& projectRootDirectory,
+    const std::optional<Project>& project,
+    const juce::String& branchId,
+    const juce::String& commitMessage,
+    const juce::String& dawName)
+{
+    PushVersionJobResult result;
+
+    if (!hasProjectAndBranchSelected(project, branchId))
+    {
+        result.errorMessage = "Choose or create a project before saving.";
+        return result;
+    }
+    if (!projectFile.existsAsFile())
+    {
+        result.errorMessage = "Choose a project file before saving.";
+        return result;
+    }
+    if (!projectRootDirectory.isDirectory())
+    {
+        result.errorMessage = "Choose a valid project file before saving.";
+        return result;
+    }
+    if (hasCleanWorkingCopy(projectFile))
+    {
+        result.errorMessage = "No local project file changes detected on disk. Save the project in FL Studio first, then click Save again.";
+        return result;
+    }
+
+    ProjectVersionContext context;
+    context.projectId = project->id;
+    context.branchId = branchId;
+    context.lastVersionId = workingCopyVersionId.isNotEmpty() ? workingCopyVersionId
+                                                             : versionControlService.getLastVersionId();
+    versionControlService.setCurrentProjectContext(context);
+
+    SnapshotBundleRequest bundleRequest;
+    bundleRequest.sourceProjectFile = projectFile;
+    bundleRequest.sourceDaw = dawName;
+    bundleRequest.projectRootDirectory = projectRootDirectory;
+
+    SnapshotBundler bundler;
+    ContentAddressedManifest manifest;
+    const auto manifestStatus = bundler.buildContentAddressedManifest(bundleRequest, manifest);
+    if (manifestStatus.failed())
+    {
+        result.errorMessage = manifestStatus.getErrorMessage();
+        return result;
+    }
+
+    PushVersionCasRequest casRequest;
+    casRequest.projectId = project->id;
+    casRequest.branchId = branchId;
+    casRequest.commitMessage = commitMessage;
+    casRequest.parentVersionId = context.lastVersionId;
+    casRequest.manifest = std::move(manifest);
+
+    const auto pushStatus = versionControlService.pushVersionContentAddressed(casRequest);
+    if (pushStatus.failed())
+    {
+        result.errorMessage = pushStatus.getErrorMessage();
+        return result;
+    }
+
+    result.pushedVersionId = versionControlService.getLastVersionId();
+    result.activeProjectStatusMessage = "Version saved successfully.";
+    return result;
+}
+
 StemhubAudioProcessor::RestoreVersionJobResult StemhubAudioProcessor::performRestoreVersionRequest(
     const juce::String& versionId,
     const juce::File& destinationFile) const

--- a/plugin/stemhub/Source/src/application/SnapshotBundler.cpp
+++ b/plugin/stemhub/Source/src/application/SnapshotBundler.cpp
@@ -5,6 +5,17 @@
 
 namespace
 {
+    juce::String sha256HexOfFile(const juce::File& file)
+    {
+        juce::FileInputStream stream(file);
+        if (!stream.openedOk())
+            return {};
+        return juce::SHA256(stream).toHexString();
+    }
+}
+
+namespace
+{
     constexpr std::array<const char*, 9> kBundledAssetExtensions = {
         "wav", "mp3", "flac", "ogg", "aiff", "aif", "m4a", "mid", "midi"
     };
@@ -167,5 +178,99 @@ juce::Result SnapshotBundler::bundleProject(const SnapshotBundleRequest& request
 
     outResult.bundleFile = bundleFile;
     outResult.manifest = manifest;
+    return juce::Result::ok();
+}
+
+juce::Result SnapshotBundler::buildContentAddressedManifest(const SnapshotBundleRequest& request,
+                                                              ContentAddressedManifest& outResult) const
+{
+    outResult = {};
+
+    if (!request.sourceProjectFile.existsAsFile())
+        return juce::Result::fail("Source project file does not exist.");
+
+    if (!request.projectRootDirectory.isDirectory())
+        return juce::Result::fail("Project root directory does not exist.");
+
+    if (!isSourceFileWithinRoot(request.sourceProjectFile, request.projectRootDirectory))
+        return juce::Result::fail("Project file must be inside the selected project root directory.");
+
+    juce::Array<juce::File> discoveredFiles;
+    request.projectRootDirectory.findChildFiles(discoveredFiles, juce::File::findFiles, true);
+
+    if (discoveredFiles.isEmpty())
+        return juce::Result::fail("Project root directory does not contain files to bundle.");
+
+    std::sort(discoveredFiles.begin(), discoveredFiles.end(), [](const juce::File& lhs, const juce::File& rhs)
+    {
+        return lhs.getFullPathName() < rhs.getFullPathName();
+    });
+
+    std::vector<ContentAddressedFileEntry> entries;
+    entries.reserve(static_cast<size_t>(discoveredFiles.size()));
+    ContentAddressedFileEntry projectEntry;
+    bool haveProjectEntry = false;
+
+    for (const auto& file : discoveredFiles)
+    {
+        if (!shouldIncludeInSnapshot(file, request.projectRootDirectory, request.sourceProjectFile))
+            continue;
+
+        const auto sha = sha256HexOfFile(file);
+        if (sha.isEmpty())
+            return juce::Result::fail("Failed to hash file: " + file.getFullPathName());
+
+        ContentAddressedFileEntry entry;
+        entry.file = file;
+        entry.sha256 = sha;
+        entry.sizeBytes = file.getSize();
+        entry.filename = file.getFileName();
+        entry.isProjectFile = (file == request.sourceProjectFile);
+
+        if (entry.isProjectFile)
+        {
+            projectEntry = entry;
+            haveProjectEntry = true;
+        }
+        else
+        {
+            entries.push_back(entry);
+        }
+    }
+
+    if (!haveProjectEntry)
+        return juce::Result::fail("Project file was not included in the discovered set.");
+
+    juce::DynamicObject::Ptr projectFileObj = new juce::DynamicObject();
+    projectFileObj->setProperty("sha256", projectEntry.sha256);
+    projectFileObj->setProperty("size_bytes", projectEntry.sizeBytes);
+    projectFileObj->setProperty("filename", projectEntry.filename);
+
+    juce::Array<juce::var> tracks;
+    tracks.ensureStorageAllocated(static_cast<int>(entries.size()));
+    for (const auto& e : entries)
+    {
+        juce::DynamicObject::Ptr t = new juce::DynamicObject();
+        t->setProperty("sha256", e.sha256);
+        t->setProperty("size_bytes", e.sizeBytes);
+        t->setProperty("filename", e.filename);
+        t->setProperty("name", e.file.getFileNameWithoutExtension());
+        tracks.add(juce::var(t.get()));
+    }
+
+    juce::DynamicObject::Ptr manifest = new juce::DynamicObject();
+    manifest->setProperty("manifest_version", 1);
+    manifest->setProperty("source_daw", request.sourceDaw);
+    manifest->setProperty("source_project_filename", projectEntry.filename);
+    manifest->setProperty("project_file", juce::var(projectFileObj.get()));
+    manifest->setProperty("tracks", juce::var(tracks));
+
+    outResult.manifestJson = juce::var(manifest.get());
+    // Combine project + tracks so callers can iterate every blob to upload.
+    outResult.entries.reserve(entries.size() + 1);
+    outResult.entries.push_back(projectEntry);
+    for (auto& e : entries)
+        outResult.entries.push_back(std::move(e));
+
     return juce::Result::ok();
 }

--- a/plugin/stemhub/Source/src/application/SnapshotBundler.cpp
+++ b/plugin/stemhub/Source/src/application/SnapshotBundler.cpp
@@ -274,3 +274,56 @@ juce::Result SnapshotBundler::buildContentAddressedManifest(const SnapshotBundle
 
     return juce::Result::ok();
 }
+
+namespace
+{
+    bool readBlobRef(const juce::var& value, ParsedManifestEntry& outEntry)
+    {
+        auto* obj = value.getDynamicObject();
+        if (obj == nullptr)
+            return false;
+
+        outEntry.sha256 = obj->getProperty("sha256").toString().toLowerCase();
+        outEntry.filename = obj->getProperty("filename").toString();
+        outEntry.sizeBytes = static_cast<juce::int64>(obj->getProperty("size_bytes"));
+        return outEntry.sha256.length() == 64 && outEntry.filename.isNotEmpty();
+    }
+}
+
+juce::Result SnapshotBundler::parseContentAddressedManifest(const juce::var& manifestJson,
+                                                              ParsedManifest& outResult)
+{
+    outResult = {};
+
+    auto* root = manifestJson.getDynamicObject();
+    if (root == nullptr)
+        return juce::Result::fail("Manifest is not a JSON object.");
+
+    const auto version = static_cast<int>(root->getProperty("manifest_version"));
+    if (version != 1)
+        return juce::Result::fail("Unsupported manifest_version: " + juce::String(version));
+
+    outResult.manifestVersion = version;
+    outResult.sourceDaw = root->getProperty("source_daw").toString();
+    outResult.sourceProjectFilename = root->getProperty("source_project_filename").toString();
+
+    ParsedManifestEntry projectEntry;
+    if (!readBlobRef(root->getProperty("project_file"), projectEntry))
+        return juce::Result::fail("Manifest project_file is missing or malformed.");
+    projectEntry.isProjectFile = true;
+    outResult.entries.push_back(std::move(projectEntry));
+
+    const auto tracksVar = root->getProperty("tracks");
+    if (tracksVar.isArray())
+    {
+        for (const auto& trackVar : *tracksVar.getArray())
+        {
+            ParsedManifestEntry entry;
+            if (!readBlobRef(trackVar, entry))
+                return juce::Result::fail("Manifest track entry is malformed.");
+            outResult.entries.push_back(std::move(entry));
+        }
+    }
+
+    return juce::Result::ok();
+}

--- a/plugin/stemhub/Source/src/network/ApiClient.cpp
+++ b/plugin/stemhub/Source/src/network/ApiClient.cpp
@@ -449,3 +449,15 @@ ApiResult<juce::var> ApiClient::createVersionFromManifest(const juce::String& br
         return { {}, jsonResult.error };
     return { *jsonResult.value, {} };
 }
+
+juce::Result ApiClient::downloadBlob(const juce::String& projectId,
+                                       const juce::String& sha256,
+                                       const juce::File& destinationFile,
+                                       const juce::String& accessToken) const
+{
+    // Reuse the existing downloadFile plumbing. Backend may 307-redirect to
+    // a presigned URL (GCS); juce::URL's input stream follows redirects.
+    return downloadFile("/projects/" + projectId + "/blobs/" + sha256,
+                        destinationFile,
+                        accessToken);
+}

--- a/plugin/stemhub/Source/src/network/ApiClient.cpp
+++ b/plugin/stemhub/Source/src/network/ApiClient.cpp
@@ -368,3 +368,84 @@ ApiResult<std::vector<Branch>> ApiClient::fetchBranches(const juce::String& proj
 
     return { branches, {} };
 }
+
+ApiResult<std::vector<juce::String>> ApiClient::checkMissingBlobs(const juce::String& projectId,
+                                                                   const std::vector<juce::String>& sha256s,
+                                                                   const juce::String& accessToken) const
+{
+    auto* obj = new juce::DynamicObject();
+    juce::Array<juce::var> arr;
+    arr.ensureStorageAllocated(static_cast<int>(sha256s.size()));
+    for (const auto& sha : sha256s)
+        arr.add(sha);
+    obj->setProperty("sha256s", arr);
+    const auto body = juce::JSON::toString(juce::var(obj));
+
+    const auto path = "/projects/" + projectId + "/blobs/check-missing";
+    const auto jsonResult = requestJson(path, "POST", body, accessToken);
+    if (!jsonResult.ok())
+        return { {}, jsonResult.error };
+
+    const auto missingVar = jsonResult.value->getProperty("missing", juce::var());
+    if (!missingVar.isArray())
+        return { {}, ApiError { 200, "check-missing response has no 'missing' array." } };
+
+    std::vector<juce::String> missing;
+    const auto* missingArray = missingVar.getArray();
+    missing.reserve(static_cast<size_t>(missingArray->size()));
+    for (const auto& item : *missingArray)
+        missing.push_back(item.toString());
+
+    return { missing, {} };
+}
+
+ApiResult<juce::var> ApiClient::uploadBlob(const juce::String& projectId,
+                                            const juce::String& sha256,
+                                            const juce::File& file,
+                                            const juce::String& accessToken) const
+{
+    if (!file.existsAsFile())
+        return { {}, ApiError { 0, "Blob source file does not exist." } };
+
+    // Backend expects multipart/form-data with a "file" field, PUT method.
+    // Matches routers/blobs.py::upload_blob signature.
+    const auto path = "/projects/" + projectId + "/blobs/" + sha256;
+    auto url = juce::URL(baseUrl + path).withFileToUpload("file", file, "application/octet-stream");
+
+    juce::StringPairArray responseHeaders;
+    int statusCode = 0;
+
+    auto options = juce::URL::InputStreamOptions(juce::URL::ParameterHandling::inAddress)
+        .withHttpRequestCmd("PUT")
+        .withExtraHeaders("Accept: application/json\r\nAuthorization: Bearer " + accessToken + "\r\n")
+        .withResponseHeaders(&responseHeaders)
+        .withStatusCode(&statusCode)
+        .withConnectionTimeoutMs(120000);
+
+    auto stream = url.createInputStream(options);
+    if (stream == nullptr)
+        return { {}, ApiError { statusCode, "Failed to connect to backend for blob upload." } };
+
+    const auto responseText = stream->readEntireStreamAsString();
+    const auto parsedJson = juce::JSON::parse(responseText);
+
+    if (statusCode < 200 || statusCode >= 300)
+        return { {}, ApiError { statusCode, extractErrorMessage(parsedJson, responseText, "Blob upload failed.") } };
+
+    if (parsedJson.isVoid())
+        return { {}, ApiError { statusCode, "Backend returned invalid JSON." } };
+
+    return { parsedJson, {} };
+}
+
+ApiResult<juce::var> ApiClient::createVersionFromManifest(const juce::String& branchId,
+                                                           const juce::var& payload,
+                                                           const juce::String& accessToken) const
+{
+    const auto body = juce::JSON::toString(payload);
+    const auto path = "/branches/" + branchId + "/versions/from-manifest";
+    const auto jsonResult = requestJson(path, "POST", body, accessToken);
+    if (!jsonResult.ok())
+        return { {}, jsonResult.error };
+    return { *jsonResult.value, {} };
+}

--- a/plugin/stemhub/Source/src/network/VersionControlService.cpp
+++ b/plugin/stemhub/Source/src/network/VersionControlService.cpp
@@ -1,3 +1,5 @@
+#include <set>
+
 #include "application/VersionControlService.hpp"
 
 namespace
@@ -98,6 +100,72 @@ juce::Result VersionControlService::pushVersion(const PushVersionRequest& reques
 
     context.branchId = uploadedVersion.value->branchId;
     context.lastVersionId = uploadedVersion.value->id;
+    return juce::Result::ok();
+}
+
+juce::Result VersionControlService::pushVersionContentAddressed(const PushVersionCasRequest& request)
+{
+    if (accessToken.isEmpty())
+        return juce::Result::fail("No access token is configured for version control.");
+
+    const auto* api = getApiClient();
+    if (api == nullptr)
+        return juce::Result::fail("VersionControlService API client is not configured.");
+
+    const auto projectId = request.projectId.isNotEmpty() ? request.projectId : context.projectId;
+    const auto branchId  = request.branchId.isNotEmpty()  ? request.branchId  : context.branchId;
+    if (projectId.isEmpty())
+        return juce::Result::fail("A project ID is required to push a version.");
+    if (branchId.isEmpty())
+        return juce::Result::fail("A branch ID is required to push a version.");
+    if (request.manifest.entries.empty())
+        return juce::Result::fail("Manifest has no files to upload.");
+
+    // Ask the server which blobs it already has.
+    std::vector<juce::String> allShas;
+    allShas.reserve(request.manifest.entries.size());
+    for (const auto& e : request.manifest.entries)
+        allShas.push_back(e.sha256);
+
+    const auto missingResult = api->checkMissingBlobs(projectId, allShas, accessToken);
+    if (!missingResult.ok())
+        return juce::Result::fail(buildApiErrorMessage(missingResult.error, "Failed to check missing blobs."));
+
+    // Upload only the blobs the server doesn't have.
+    std::set<juce::String> missingSet(missingResult.value->begin(), missingResult.value->end());
+    for (const auto& e : request.manifest.entries)
+    {
+        if (missingSet.find(e.sha256) == missingSet.end())
+            continue;
+
+        const auto up = api->uploadBlob(projectId, e.sha256, e.file, accessToken);
+        if (!up.ok())
+            return juce::Result::fail(buildApiErrorMessage(up.error,
+                "Failed to upload blob " + e.filename + " (" + e.sha256.substring(0, 12) + "…)."));
+    }
+
+    // Create the version referencing the manifest.
+    juce::DynamicObject::Ptr payload = new juce::DynamicObject();
+    if (request.commitMessage.isNotEmpty())
+        payload->setProperty("commit_message", request.commitMessage);
+    const auto parentId = request.parentVersionId.isNotEmpty()
+        ? request.parentVersionId
+        : context.lastVersionId;
+    if (parentId.isNotEmpty())
+        payload->setProperty("parent_version_id", parentId);
+    payload->setProperty("manifest", request.manifest.manifestJson);
+
+    const auto createResult = api->createVersionFromManifest(branchId, juce::var(payload.get()), accessToken);
+    if (!createResult.ok())
+        return juce::Result::fail(buildApiErrorMessage(createResult.error, "Failed to create version from manifest."));
+
+    const auto createdVersion = parseVersionSummary(*createResult.value);
+    if (!createdVersion.ok())
+        return juce::Result::fail(buildApiErrorMessage(createdVersion.error, "Failed to parse created version."));
+
+    context.projectId = projectId;
+    context.branchId = createdVersion.value->branchId;
+    context.lastVersionId = createdVersion.value->id;
     return juce::Result::ok();
 }
 

--- a/plugin/stemhub/Source/src/network/VersionControlService.cpp
+++ b/plugin/stemhub/Source/src/network/VersionControlService.cpp
@@ -272,3 +272,97 @@ juce::String VersionControlService::resolveParentVersionId(const PushVersionRequ
 
     return context.lastVersionId;
 }
+
+namespace
+{
+juce::String sha256HexOfLocalFile(const juce::File& file)
+{
+    juce::FileInputStream stream(file);
+    if (!stream.openedOk())
+        return {};
+    return juce::SHA256(stream).toHexString();
+}
+}
+
+juce::Result VersionControlService::restoreVersionFromManifest(const juce::String& projectId,
+                                                                 const juce::String& versionId,
+                                                                 const juce::File& restoreDirectory,
+                                                                 juce::File& outProjectFile)
+{
+    outProjectFile = juce::File();
+
+    if (accessToken.isEmpty())
+        return juce::Result::fail("No access token is configured for version control.");
+    if (versionId.isEmpty())
+        return juce::Result::fail("A version ID is required to restore a snapshot.");
+    if (projectId.isEmpty())
+        return juce::Result::fail("A project ID is required to restore a snapshot.");
+
+    const auto* api = getApiClient();
+    if (api == nullptr)
+        return juce::Result::fail("VersionControlService API client is not configured.");
+
+    // Fetch the version detail — we want manifest_json (added to
+    // VersionResponse in the CAS integration PR).
+    const auto detailResult = api->requestJson("/versions/" + versionId, "GET", {}, accessToken);
+    if (!detailResult.ok())
+        return juce::Result::fail(buildApiErrorMessage(detailResult.error, "Failed to fetch version detail."));
+
+    auto* detailObj = detailResult.value->getDynamicObject();
+    if (detailObj == nullptr)
+        return juce::Result::fail("Version detail is not a JSON object.");
+
+    const auto manifestJson = detailObj->getProperty("manifest_json");
+    if (manifestJson.isVoid() || !manifestJson.isObject())
+        return juce::Result::fail("Version has no content-addressed manifest.");
+
+    ParsedManifest parsed;
+    const auto parseStatus = SnapshotBundler::parseContentAddressedManifest(manifestJson, parsed);
+    if (parseStatus.failed())
+        return parseStatus;
+
+    if (!restoreDirectory.exists() && !restoreDirectory.createDirectory())
+        return juce::Result::fail("Failed to create restore directory: " + restoreDirectory.getFullPathName());
+    if (!restoreDirectory.isDirectory())
+        return juce::Result::fail("Restore path is not a directory: " + restoreDirectory.getFullPathName());
+
+    std::vector<juce::File> writtenFiles;
+    writtenFiles.reserve(parsed.entries.size());
+
+    for (const auto& entry : parsed.entries)
+    {
+        auto dest = restoreDirectory.getChildFile(entry.filename);
+        if (dest.existsAsFile())
+            dest.deleteFile();
+
+        const auto downloadStatus = api->downloadBlob(projectId, entry.sha256, dest, accessToken);
+        if (downloadStatus.failed())
+        {
+            for (auto& f : writtenFiles) f.deleteFile();
+            return juce::Result::fail("Failed to download blob " + entry.filename
+                                       + " (" + entry.sha256.substring(0, 12) + "..): "
+                                       + downloadStatus.getErrorMessage());
+        }
+
+        const auto localSha = sha256HexOfLocalFile(dest);
+        if (localSha != entry.sha256)
+        {
+            for (auto& f : writtenFiles) f.deleteFile();
+            dest.deleteFile();
+            return juce::Result::fail("SHA-256 mismatch for " + entry.filename
+                                       + ": expected " + entry.sha256.substring(0, 12)
+                                       + ", got " + localSha.substring(0, 12));
+        }
+
+        writtenFiles.push_back(dest);
+        if (entry.isProjectFile)
+            outProjectFile = dest;
+    }
+
+    if (!outProjectFile.existsAsFile())
+        return juce::Result::fail("Manifest did not include a project file entry.");
+
+    context.projectId = projectId;
+    context.lastVersionId = versionId;
+    return juce::Result::ok();
+}

--- a/plugin/stemhub/Source/src/ui/PluginEditor.cpp
+++ b/plugin/stemhub/Source/src/ui/PluginEditor.cpp
@@ -600,7 +600,11 @@ void StemhubAudioProcessorEditor::requestSaveWithCommitMessage(juce::String comm
 
 void StemhubAudioProcessorEditor::triggerPushVersion(const juce::String& commitMessage)
 {
-    audioProcessor.requestPushVersion(commitMessage, kDawName);
+    // Content-addressed push: uploads only novel blobs (SHA-256 dedup within
+    // the project). See docs/content-addressed-storage.md. The legacy
+    // whole-bundle path remains available via
+    // audioProcessor.requestPushVersion() if a rollback is needed.
+    audioProcessor.requestPushVersionContentAddressed(commitMessage, kDawName);
     refreshSessionUi();
 }
 

--- a/plugin/stemhub/Source/src/ui/PluginEditor.cpp
+++ b/plugin/stemhub/Source/src/ui/PluginEditor.cpp
@@ -538,7 +538,10 @@ void StemhubAudioProcessorEditor::handleRestoreClick()
                 juce::Logger::writeToLog("[Restore] UI -> requesting restore from confirmation callback: "
                                          + folder.getFullPathName() + ", version="
                                          + versionToRestore);
-                mutableEditor->audioProcessor.requestRestoreVersion(versionToRestore, folder);
+                // Content-addressed restore: pulls only referenced blobs (verified by SHA-256).
+                // See docs/content-addressed-storage.md. The legacy zip-download path remains
+                // available via audioProcessor.requestRestoreVersion() if a rollback is needed.
+                mutableEditor->audioProcessor.requestRestoreVersionContentAddressed(versionToRestore, folder);
                 mutableEditor->refreshSessionUi();
             }));
     };

--- a/plugin/stemhub/tests/ProcessorStabilityTests.cpp
+++ b/plugin/stemhub/tests/ProcessorStabilityTests.cpp
@@ -219,6 +219,15 @@ public:
         return makeApiError("createVersionFromManifest not implemented in tests");
     }
 
+    juce::Result downloadBlob(const juce::String& projectId,
+                               const juce::String& sha256,
+                               const juce::File& destinationFile,
+                               const juce::String& accessToken) const override
+    {
+        juce::ignoreUnused(projectId, sha256, destinationFile, accessToken);
+        return juce::Result::fail("downloadBlob not implemented in tests");
+    }
+
     bool cachedSessionIsValid { true };
     std::vector<Project> projects;
     std::map<juce::String, std::vector<Branch>> projectBranches;

--- a/plugin/stemhub/tests/ProcessorStabilityTests.cpp
+++ b/plugin/stemhub/tests/ProcessorStabilityTests.cpp
@@ -194,6 +194,31 @@ public:
         return juce::Result::fail("download not implemented in tests");
     }
 
+    ApiResult<std::vector<juce::String>> checkMissingBlobs(const juce::String& projectId,
+                                                            const std::vector<juce::String>& sha256s,
+                                                            const juce::String& accessToken) const override
+    {
+        juce::ignoreUnused(projectId, sha256s, accessToken);
+        return { std::vector<juce::String>{}, {} };
+    }
+
+    ApiResult<juce::var> uploadBlob(const juce::String& projectId,
+                                     const juce::String& sha256,
+                                     const juce::File& file,
+                                     const juce::String& accessToken) const override
+    {
+        juce::ignoreUnused(projectId, sha256, file, accessToken);
+        return makeApiError("uploadBlob not implemented in tests");
+    }
+
+    ApiResult<juce::var> createVersionFromManifest(const juce::String& branchId,
+                                                    const juce::var& payload,
+                                                    const juce::String& accessToken) const override
+    {
+        juce::ignoreUnused(branchId, payload, accessToken);
+        return makeApiError("createVersionFromManifest not implemented in tests");
+    }
+
     bool cachedSessionIsValid { true };
     std::vector<Project> projects;
     std::map<juce::String, std::vector<Branch>> projectBranches;


### PR DESCRIPTION
## Summary

Follow-up to the backend/database audit. Two logical commits:

1. **`feat(backend): harden auth, add observability, add User soft-delete`** — SECRET_KEY startup guard (rejects short/default keys), JWT TTL 7d → 24h, `/health` + `/ready` endpoints, stdlib JSON logging + `X-Request-ID` middleware, `User.is_deleted` + `deleted_at` (indexed) so deleted accounts stop leaking into public feeds. Includes migration `e3a1c9f2b7d0` and a `conftest.py` that sets a test SECRET_KEY.

2. **`feat(backend): content-addressed storage foundation`** — new project-scoped `Blob(project_id, sha256)` table with `ref_count`, `Version.manifest_json` + `manifest_version` columns, blob endpoints on `/projects/{pid}/blobs/*` (check-missing / PUT with SHA-256 verification / GET), and `store_blob` / `resolve_blob_path` / `delete_blob` on both storage services. Also fixes a checksum-semantics mismatch: `GCSStorageService` now streams uploads through a SHA-256 hasher instead of returning GCS-native MD5. Migration `f7d2c1a48901`. See `docs/content-addressed-storage.md` for the full design (why project-scoped over global, GC strategy, presigned-URL migration path, manifest schema versioning).

**Not in this PR** — the plugin and existing `POST /versions` endpoint still use the whole-artifact path. A follow-up PR will add a manifest-based version endpoint and teach the JUCE plugin to hash → check-missing → upload only novel blobs.

**Note:** `docs/DATA_API_MODELING.md` had pre-existing uncommitted edits before this work started; those are intentionally left out of this PR.

## Migrations

Both new migrations chain onto the current head `c1a2b3d4e5f7`:
- `e3a1c9f2b7d0_add_user_soft_delete` — adds `users.is_deleted` + `users.deleted_at` + index.
- `f7d2c1a48901_add_blob_and_manifest` — creates `blob` table + adds `version.manifest_json` + `version.manifest_version`.

Apply with `docker compose exec backend alembic upgrade head`.

## Test plan

- [x] `pytest backend/tests` — 42/42 non-PyFLP tests pass locally (3 PyFLP-dependent tests skipped due to a local submodule setup issue unrelated to this PR; CI has the submodule and should run all tests).
- [x] SECRET_KEY guard verified: importing `stemhub.security` without `SECRET_KEY` set raises `RuntimeError`.
- [x] `TestClient` smoke: `/health` → 200, `/` → 200, `/projects/.../blobs/check-missing` without auth → 401 (route registered).
- [x] Structured JSON logs emit with `request_id`, `duration_ms`, `path`, `method`, `status`.
- [ ] Deploy target (docker compose): apply both migrations, restart backend, hit `/health` and `/ready`.
- [ ] Manual: create a project, `PUT /projects/{pid}/blobs/{sha256}` with a small file, verify blob row and file on disk (localfs); repeat upload → returns existing blob (200) without re-uploading; upload with wrong sha256 → 400 and no row created.