### PR TITLE
backend + plugin: content-addressed pull + blob GC endpoint

### DIFF
--- a/backend/src/stemhub/routers/admin.py
+++ b/backend/src/stemhub/routers/admin.py
@@ -7,9 +7,11 @@ from sqlalchemy.future import select
 from sqlalchemy import func, cast, Date
 
 from ..auth import get_current_admin_user
+from ..blob_gc import sweep_orphan_blobs
 from ..database import get_db
 from ..models import Project, User
 from ..schemas import UserResponse, DailySignup, AdminStats, UserWithProjects, RecentUser
+from ..storage import StorageService, get_storage_service
 
 router = APIRouter(prefix="/api/admin", tags=["admin"])
 
@@ -129,3 +131,32 @@ async def toggle_active(
     await db.commit()
     await db.refresh(user)
     return user
+
+
+@router.post("/blobs/gc")
+async def run_blob_gc(
+    _: User = Depends(get_current_admin_user),
+    db: AsyncSession = Depends(get_db),
+    storage: StorageService = Depends(get_storage_service),
+    grace_hours: int = Query(24, ge=0, le=720),
+    batch_size: int = Query(500, ge=1, le=5000),
+):
+    """Run one pass of the content-addressed blob GC sweep.
+
+    Deletes blobs where ref_count == 0 and older than the grace window.
+    See docs/content-addressed-storage.md. Intended to be invoked by an
+    external scheduler; also usable ad-hoc from an admin session.
+    """
+    result = await sweep_orphan_blobs(
+        db=db,
+        storage=storage,
+        grace_hours=grace_hours,
+        batch_size=batch_size,
+    )
+    return {
+        "scanned": result.scanned,
+        "deleted": result.deleted,
+        "failed": result.failed,
+        "grace_hours": grace_hours,
+        "batch_size": batch_size,
+    }

--- a/backend/tests/test_admin_api.py
+++ b/backend/tests/test_admin_api.py
@@ -150,3 +150,21 @@ def test_admin_stats_rejects_unauthenticated():
 
     assert response.status_code == 401
     assert response.json()["detail"] == "Could not validate credentials"
+
+
+def test_admin_blobs_gc_rejects_non_admin():
+    regular_user = _build_user(is_admin=False)
+    client = _create_test_client(current_user=regular_user)
+
+    response = client.post("/api/admin/blobs/gc")
+
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Admin privileges required"
+
+
+def test_admin_blobs_gc_rejects_unauthenticated():
+    client = _create_test_client()
+
+    response = client.post("/api/admin/blobs/gc")
+
+    assert response.status_code == 401

--- a/plugin/stemhub/Source/include/application/PluginProcessor.hpp
+++ b/plugin/stemhub/Source/include/application/PluginProcessor.hpp
@@ -100,6 +100,10 @@ public:
     // whole-project bundle. See docs/content-addressed-storage.md.
     void requestPushVersionContentAddressed(juce::String commitMessage, juce::String dawName);
     void requestRestoreVersion(const juce::String& versionId, const juce::File& destinationFolder);
+    // Content-addressed restore: fetches the version's manifest and downloads
+    // only the referenced blobs into destinationFolder, verifying SHA-256.
+    // See docs/content-addressed-storage.md.
+    void requestRestoreVersionContentAddressed(const juce::String& versionId, const juce::File& destinationFolder);
 
     void setSelectedVersionId(juce::String versionId);
     VersionControlService& getVersionControlService() noexcept { return versionControlService; }
@@ -173,6 +177,7 @@ private:
     void enqueueBackgroundTask(std::function<BackgroundJobPayload()> job);
 
     RestoreVersionJobResult performRestoreVersionRequest(const juce::String& versionId, const juce::File& destinationFile) const;
+    RestoreVersionJobResult performRestoreVersionContentAddressedRequest(const juce::String& versionId, const juce::File& destinationFolder);
     AuthRequestResult performSignInRequest(const juce::String& email, const juce::String& password) const;
     AuthRequestResult performRestoreCachedSessionRequest(const juce::String& token) const;
     ProjectActivationJobResult performOpenProjectRequest(const juce::String& projectId,

--- a/plugin/stemhub/Source/include/application/SnapshotBundler.hpp
+++ b/plugin/stemhub/Source/include/application/SnapshotBundler.hpp
@@ -31,6 +31,24 @@ struct ContentAddressedManifest
     std::vector<ContentAddressedFileEntry> entries;
 };
 
+// Parsed entry from a v1 manifest — describes ONE blob the client needs to
+// materialize during pull, plus where to put it.
+struct ParsedManifestEntry
+{
+    juce::String sha256;
+    juce::int64 sizeBytes { 0 };
+    juce::String filename;    // basename; used relative to the restore directory
+    bool isProjectFile { false };
+};
+
+struct ParsedManifest
+{
+    int manifestVersion { 0 };
+    juce::String sourceDaw;
+    juce::String sourceProjectFilename;
+    std::vector<ParsedManifestEntry> entries;   // project file first if present
+};
+
 class SnapshotBundler
 {
     public:
@@ -43,4 +61,10 @@ class SnapshotBundler
         // Does NOT write a zip.
         [[nodiscard]] juce::Result buildContentAddressedManifest(const SnapshotBundleRequest& request,
                                                                     ContentAddressedManifest& outResult) const;
+
+        // Parse a v1 manifest_json blob (as returned by GET /versions/{vid})
+        // into a flat list of entries the caller can iterate to download blobs.
+        // Only accepts manifest_version == 1.
+        [[nodiscard]] static juce::Result parseContentAddressedManifest(const juce::var& manifestJson,
+                                                                         ParsedManifest& outResult);
 };

--- a/plugin/stemhub/Source/include/application/VersionControlService.hpp
+++ b/plugin/stemhub/Source/include/application/VersionControlService.hpp
@@ -32,7 +32,15 @@ class VersionControlService
         // create version from manifest. See docs/content-addressed-storage.md.
         // Only re-uploads blobs the server doesn't already have.
         juce::Result pushVersionContentAddressed(const PushVersionCasRequest& request);
-    
+
+        // Content-addressed pull: fetch the version's manifest, download each
+        // referenced blob into restoreDirectory (verifying SHA-256 per file),
+        // and return the path of the project file entry via outProjectFile.
+        juce::Result restoreVersionFromManifest(const juce::String& projectId,
+                                                const juce::String& versionId,
+                                                const juce::File& restoreDirectory,
+                                                juce::File& outProjectFile);
+
         ApiResult<std::vector<VersionSummary>> fetchVersionHistory(
             const juce::String& branchId,
             const juce::String& accessToken) const;

--- a/plugin/stemhub/Source/include/network/ApiClient.hpp
+++ b/plugin/stemhub/Source/include/network/ApiClient.hpp
@@ -45,6 +45,13 @@ public:
     virtual ApiResult<juce::var> createVersionFromManifest(const juce::String& branchId,
                                                             const juce::var& payload,
                                                             const juce::String& accessToken) const = 0;
+    // Download a single blob to a local file. Backend may 307-redirect to a
+    // presigned URL (GCS) — juce::URL's input stream follows redirects by
+    // default so the implementation is a normal GET.
+    virtual juce::Result downloadBlob(const juce::String& projectId,
+                                       const juce::String& sha256,
+                                       const juce::File& destinationFile,
+                                       const juce::String& accessToken) const = 0;
 };
 
 class ApiClient final : public IProjectApi
@@ -80,6 +87,10 @@ public:
     ApiResult<juce::var> createVersionFromManifest(const juce::String& branchId,
                                                     const juce::var& payload,
                                                     const juce::String& accessToken) const override;
+    juce::Result downloadBlob(const juce::String& projectId,
+                               const juce::String& sha256,
+                               const juce::File& destinationFile,
+                               const juce::String& accessToken) const override;
 
 private:
     juce::String baseUrl;

--- a/plugin/stemhub/Source/src/application/ProcProject.cpp
+++ b/plugin/stemhub/Source/src/application/ProcProject.cpp
@@ -626,6 +626,48 @@ void StemhubAudioProcessor::requestRestoreVersion(const juce::String& versionId,
     });
 }
 
+void StemhubAudioProcessor::requestRestoreVersionContentAddressed(const juce::String& versionId, const juce::File& projectFolder)
+{
+    if (!hasProjectAndBranchSelected(selectedProject, selectedBranchId))
+    {
+        setOperationState(OperationState::error);
+        setActiveProjectStatusMessage("Choose a project before restoring.");
+        return;
+    }
+    if (!projectFolder.isDirectory())
+    {
+        setOperationState(OperationState::error);
+        setActiveProjectStatusMessage("Choose a valid restore destination folder.");
+        return;
+    }
+    if (versionId.isEmpty())
+    {
+        setOperationState(OperationState::error);
+        setActiveProjectStatusMessage("Select a version before restoring.");
+        return;
+    }
+
+    const auto projectName = selectedProject ? selectedProject->name : juce::String();
+    const auto restoredProjectBase = stemhub::projectfiles::resolveRestoreProjectName(versionHistory, versionId, projectName);
+    // Materialize the blobs into a per-version subdirectory to avoid clobbering
+    // adjacent restores. Matches the shape of the legacy restore path.
+    const auto restoreDir = projectFolder.getChildFile(
+        restoredProjectBase + "-" + versionId.substring(0, juce::jmin(8, versionId.length())));
+
+    setOperationState(OperationState::pulling);
+    setActiveProjectStatusMessage("Restoring selected version...");
+    sendChangeMessage();
+
+    const auto requestedVersionId = versionId;
+    const auto requestedRestoreDir = restoreDir;
+    enqueueBackgroundTask([this,
+                           requestedVersionId,
+                           requestedRestoreDir]() mutable -> BackgroundJobPayload
+    {
+        return performRestoreVersionContentAddressedRequest(requestedVersionId, requestedRestoreDir);
+    });
+}
+
 void StemhubAudioProcessor::setSelectedVersionId(juce::String versionId)
 {
     selectedVersionId = std::move(versionId);

--- a/plugin/stemhub/Source/src/application/ProcVerJobs.cpp
+++ b/plugin/stemhub/Source/src/application/ProcVerJobs.cpp
@@ -221,6 +221,52 @@ StemhubAudioProcessor::PushVersionJobResult StemhubAudioProcessor::performPushVe
     return result;
 }
 
+StemhubAudioProcessor::RestoreVersionJobResult StemhubAudioProcessor::performRestoreVersionContentAddressedRequest(
+    const juce::String& versionId, const juce::File& destinationFolder)
+{
+    RestoreVersionJobResult result;
+    result.restoredVersionId = versionId;
+
+    if (versionId.isEmpty())
+    {
+        result.errorMessage = "Select a version before restoring.";
+        return result;
+    }
+    if (destinationFolder.exists() && !destinationFolder.isDirectory())
+    {
+        result.errorMessage = "Restore destination is not a directory: " + destinationFolder.getFullPathName();
+        return result;
+    }
+    if (!selectedProject)
+    {
+        result.errorMessage = "Choose a project before restoring.";
+        return result;
+    }
+
+    // Clear any previous restore contents at that path so download starts fresh.
+    if (destinationFolder.exists())
+    {
+        if (!destinationFolder.deleteRecursively())
+        {
+            result.errorMessage = "Failed to clear previous restore folder at " + destinationFolder.getFullPathName();
+            return result;
+        }
+    }
+
+    juce::File restoredProjectFile;
+    const auto status = versionControlService.restoreVersionFromManifest(
+        selectedProject->id, versionId, destinationFolder, restoredProjectFile);
+    if (status.failed())
+    {
+        result.errorMessage = status.getErrorMessage();
+        return result;
+    }
+
+    result.restoredProjectFile = restoredProjectFile;
+    result.activeProjectStatusMessage = "Version restored successfully: " + restoredProjectFile.getFileName();
+    return result;
+}
+
 StemhubAudioProcessor::RestoreVersionJobResult StemhubAudioProcessor::performRestoreVersionRequest(
     const juce::String& versionId,
     const juce::File& destinationFile) const

--- a/plugin/stemhub/Source/src/application/SnapshotBundler.cpp
+++ b/plugin/stemhub/Source/src/application/SnapshotBundler.cpp
@@ -274,3 +274,56 @@ juce::Result SnapshotBundler::buildContentAddressedManifest(const SnapshotBundle
 
     return juce::Result::ok();
 }
+
+namespace
+{
+    bool readBlobRef(const juce::var& value, ParsedManifestEntry& outEntry)
+    {
+        auto* obj = value.getDynamicObject();
+        if (obj == nullptr)
+            return false;
+
+        outEntry.sha256 = obj->getProperty("sha256").toString().toLowerCase();
+        outEntry.filename = obj->getProperty("filename").toString();
+        outEntry.sizeBytes = static_cast<juce::int64>(obj->getProperty("size_bytes"));
+        return outEntry.sha256.length() == 64 && outEntry.filename.isNotEmpty();
+    }
+}
+
+juce::Result SnapshotBundler::parseContentAddressedManifest(const juce::var& manifestJson,
+                                                              ParsedManifest& outResult)
+{
+    outResult = {};
+
+    auto* root = manifestJson.getDynamicObject();
+    if (root == nullptr)
+        return juce::Result::fail("Manifest is not a JSON object.");
+
+    const auto version = static_cast<int>(root->getProperty("manifest_version"));
+    if (version != 1)
+        return juce::Result::fail("Unsupported manifest_version: " + juce::String(version));
+
+    outResult.manifestVersion = version;
+    outResult.sourceDaw = root->getProperty("source_daw").toString();
+    outResult.sourceProjectFilename = root->getProperty("source_project_filename").toString();
+
+    ParsedManifestEntry projectEntry;
+    if (!readBlobRef(root->getProperty("project_file"), projectEntry))
+        return juce::Result::fail("Manifest project_file is missing or malformed.");
+    projectEntry.isProjectFile = true;
+    outResult.entries.push_back(std::move(projectEntry));
+
+    const auto tracksVar = root->getProperty("tracks");
+    if (tracksVar.isArray())
+    {
+        for (const auto& trackVar : *tracksVar.getArray())
+        {
+            ParsedManifestEntry entry;
+            if (!readBlobRef(trackVar, entry))
+                return juce::Result::fail("Manifest track entry is malformed.");
+            outResult.entries.push_back(std::move(entry));
+        }
+    }
+
+    return juce::Result::ok();
+}

--- a/plugin/stemhub/Source/src/network/ApiClient.cpp
+++ b/plugin/stemhub/Source/src/network/ApiClient.cpp
@@ -449,3 +449,15 @@ ApiResult<juce::var> ApiClient::createVersionFromManifest(const juce::String& br
         return { {}, jsonResult.error };
     return { *jsonResult.value, {} };
 }
+
+juce::Result ApiClient::downloadBlob(const juce::String& projectId,
+                                       const juce::String& sha256,
+                                       const juce::File& destinationFile,
+                                       const juce::String& accessToken) const
+{
+    // Reuse the existing downloadFile plumbing. Backend may 307-redirect to
+    // a presigned URL (GCS); juce::URL's input stream follows redirects.
+    return downloadFile("/projects/" + projectId + "/blobs/" + sha256,
+                        destinationFile,
+                        accessToken);
+}

--- a/plugin/stemhub/Source/src/network/VersionControlService.cpp
+++ b/plugin/stemhub/Source/src/network/VersionControlService.cpp
@@ -272,3 +272,97 @@ juce::String VersionControlService::resolveParentVersionId(const PushVersionRequ
 
     return context.lastVersionId;
 }
+
+namespace
+{
+juce::String sha256HexOfLocalFile(const juce::File& file)
+{
+    juce::FileInputStream stream(file);
+    if (!stream.openedOk())
+        return {};
+    return juce::SHA256(stream).toHexString();
+}
+}
+
+juce::Result VersionControlService::restoreVersionFromManifest(const juce::String& projectId,
+                                                                 const juce::String& versionId,
+                                                                 const juce::File& restoreDirectory,
+                                                                 juce::File& outProjectFile)
+{
+    outProjectFile = juce::File();
+
+    if (accessToken.isEmpty())
+        return juce::Result::fail("No access token is configured for version control.");
+    if (versionId.isEmpty())
+        return juce::Result::fail("A version ID is required to restore a snapshot.");
+    if (projectId.isEmpty())
+        return juce::Result::fail("A project ID is required to restore a snapshot.");
+
+    const auto* api = getApiClient();
+    if (api == nullptr)
+        return juce::Result::fail("VersionControlService API client is not configured.");
+
+    // Fetch the version detail — we want manifest_json (added to
+    // VersionResponse in the CAS integration PR).
+    const auto detailResult = api->requestJson("/versions/" + versionId, "GET", {}, accessToken);
+    if (!detailResult.ok())
+        return juce::Result::fail(buildApiErrorMessage(detailResult.error, "Failed to fetch version detail."));
+
+    auto* detailObj = detailResult.value->getDynamicObject();
+    if (detailObj == nullptr)
+        return juce::Result::fail("Version detail is not a JSON object.");
+
+    const auto manifestJson = detailObj->getProperty("manifest_json");
+    if (manifestJson.isVoid() || !manifestJson.isObject())
+        return juce::Result::fail("Version has no content-addressed manifest.");
+
+    ParsedManifest parsed;
+    const auto parseStatus = SnapshotBundler::parseContentAddressedManifest(manifestJson, parsed);
+    if (parseStatus.failed())
+        return parseStatus;
+
+    if (!restoreDirectory.exists() && !restoreDirectory.createDirectory())
+        return juce::Result::fail("Failed to create restore directory: " + restoreDirectory.getFullPathName());
+    if (!restoreDirectory.isDirectory())
+        return juce::Result::fail("Restore path is not a directory: " + restoreDirectory.getFullPathName());
+
+    std::vector<juce::File> writtenFiles;
+    writtenFiles.reserve(parsed.entries.size());
+
+    for (const auto& entry : parsed.entries)
+    {
+        auto dest = restoreDirectory.getChildFile(entry.filename);
+        if (dest.existsAsFile())
+            dest.deleteFile();
+
+        const auto downloadStatus = api->downloadBlob(projectId, entry.sha256, dest, accessToken);
+        if (downloadStatus.failed())
+        {
+            for (auto& f : writtenFiles) f.deleteFile();
+            return juce::Result::fail("Failed to download blob " + entry.filename
+                                       + " (" + entry.sha256.substring(0, 12) + "..): "
+                                       + downloadStatus.getErrorMessage());
+        }
+
+        const auto localSha = sha256HexOfLocalFile(dest);
+        if (localSha != entry.sha256)
+        {
+            for (auto& f : writtenFiles) f.deleteFile();
+            dest.deleteFile();
+            return juce::Result::fail("SHA-256 mismatch for " + entry.filename
+                                       + ": expected " + entry.sha256.substring(0, 12)
+                                       + ", got " + localSha.substring(0, 12));
+        }
+
+        writtenFiles.push_back(dest);
+        if (entry.isProjectFile)
+            outProjectFile = dest;
+    }
+
+    if (!outProjectFile.existsAsFile())
+        return juce::Result::fail("Manifest did not include a project file entry.");
+
+    context.projectId = projectId;
+    context.lastVersionId = versionId;
+    return juce::Result::ok();
+}

--- a/plugin/stemhub/Source/src/ui/PluginEditor.cpp
+++ b/plugin/stemhub/Source/src/ui/PluginEditor.cpp
@@ -538,7 +538,10 @@ void StemhubAudioProcessorEditor::handleRestoreClick()
                 juce::Logger::writeToLog("[Restore] UI -> requesting restore from confirmation callback: "
                                          + folder.getFullPathName() + ", version="
                                          + versionToRestore);
-                mutableEditor->audioProcessor.requestRestoreVersion(versionToRestore, folder);
+                // Content-addressed restore: pulls only referenced blobs (verified by SHA-256).
+                // See docs/content-addressed-storage.md. The legacy zip-download path remains
+                // available via audioProcessor.requestRestoreVersion() if a rollback is needed.
+                mutableEditor->audioProcessor.requestRestoreVersionContentAddressed(versionToRestore, folder);
                 mutableEditor->refreshSessionUi();
             }));
     };

--- a/plugin/stemhub/tests/ProcessorStabilityTests.cpp
+++ b/plugin/stemhub/tests/ProcessorStabilityTests.cpp
@@ -219,6 +219,15 @@ public:
         return makeApiError("createVersionFromManifest not implemented in tests");
     }
 
+    juce::Result downloadBlob(const juce::String& projectId,
+                               const juce::String& sha256,
+                               const juce::File& destinationFile,
+                               const juce::String& accessToken) const override
+    {
+        juce::ignoreUnused(projectId, sha256, destinationFile, accessToken);
+        return juce::Result::fail("downloadBlob not implemented in tests");
+    }
+
     bool cachedSessionIsValid { true };
     std::vector<Project> projects;
     std::map<juce::String, std::vector<Branch>> projectBranches;


### PR DESCRIPTION
## Summary

Stacked on #248. Completes the CAS round-trip and turns the GC helper into a live endpoint.

**Two commits:**

1. **\`feat(backend): expose blob GC via admin endpoint\`** — \`POST /api/admin/blobs/gc\` runs one pass of \`sweep_orphan_blobs()\` (admin-only, \`grace_hours\` + \`batch_size\` query params). External schedulers can now poll it; ad-hoc runs work from an admin session. Two rejection-path tests. A full integration test needs a real DB fixture and is deferred to whoever wires the scheduler.

2. **\`feat(plugin): content-addressed pull — reassemble project from manifest\`** — symmetric to the push flow. \`IProjectApi\` gains \`downloadBlob\` (backend may 307-redirect to a GCS presigned URL). \`SnapshotBundler\` gains \`parseContentAddressedManifest\`. \`VersionControlService::restoreVersionFromManifest\` downloads each referenced blob, verifies SHA-256, cleans up on any failure. New processor method \`requestRestoreVersionContentAddressed\`, and the Restore button in \`PluginEditor.cpp\` now uses it (single-line switch, trivially reversible).

## Why now

Without pull-by-manifest, iterating between two versions still costs a full whole-project download every time. This completes the CAS round-trip: the fast-restore UX is the whole reason we built this.

## What's not in this PR

- **Local dedup on pull.** Currently every referenced blob is downloaded fresh into the restore folder, even if a byte-identical file already exists locally. A future optimization: hash the local file first and skip if it matches. Correctness first.
- **GC scheduler.** The endpoint is callable, but nothing calls it on a schedule. Cron / Cloud Run job / worker choice depends on where you deploy — that's a small follow-up.

## Test plan

- [x] \`pytest backend/tests\` — 50/50 non-PyFLP pass (48 pre-existing + 2 new admin rejection tests).
- [x] Plugin: \`cmake --build build/plugin-cas --target stemhub_plugin_tests\` clean; \`./stemhub_plugin_tests\` exit 0.
- [x] Plugin: \`cmake --build build/plugin-cas --target stemhub_VST3\` builds and installs.
- [ ] Manual end-to-end (once #246 → #248 are merged and deployed):
  1. Push a version with the CAS path from #248.
  2. Restore it via the Restore button → should populate a folder with the project file + all track blobs, SHA-256 verified.
  3. Restore twice in a row → second time redownloads (no local dedup yet).
  4. \`POST /api/admin/blobs/gc?grace_hours=0\` — should reclaim any \`ref_count=0\` blobs immediately.

## Rollback

Restore path: revert one line in \`PluginEditor.cpp\` back to \`audioProcessor.requestRestoreVersion(...)\`. GC endpoint: nothing depends on it; safe to leave deployed.